### PR TITLE
ADH-5802

### DIFF
--- a/agents-audit/src/main/java/org/apache/ranger/audit/queue/AuditFileCacheProviderSpool.java
+++ b/agents-audit/src/main/java/org/apache/ranger/audit/queue/AuditFileCacheProviderSpool.java
@@ -248,7 +248,7 @@ public class AuditFileCacheProviderSpool implements Runnable {
                             + indexDoneFile.getPath());
                     return false;
                 }
-                AuditFileUtil.setPermissions(indexFile, filePermissions);
+                AuditFileUtil.setPermissions(indexDoneFile, filePermissions);
             }
             logger.info("indexDoneFile=" + indexDoneFile + ", queueName="
                     + FILE_CACHE_PROVIDER_NAME);

--- a/agents-audit/src/main/java/org/apache/ranger/audit/queue/AuditFileCacheProviderSpool.java
+++ b/agents-audit/src/main/java/org/apache/ranger/audit/queue/AuditFileCacheProviderSpool.java
@@ -63,6 +63,7 @@ public class AuditFileCacheProviderSpool implements Runnable {
     public static final String PROP_FILE_SPOOL_LOCAL_DIR				= "filespool.dir";
     public static final String PROP_FILE_SPOOL_LOCAL_FILE_NAME 			= "filespool.filename.format";
     public static final String PROP_FILE_SPOOL_PERMS                    = "filespool.perms";
+    public static final String PROP_FILE_SPOOL_DIR_PERMS                = "filespool.dir.perms";
     public static final String PROP_FILE_SPOOL_ARCHIVE_DIR 				= "filespool.archive.dir";
     public static final String PROP_FILE_SPOOL_ARCHIVE_MAX_FILES_COUNT	= "filespool.archive.max.files";
     public static final String PROP_FILE_SPOOL_FILENAME_PREFIX 			= "filespool.file.prefix";
@@ -141,7 +142,11 @@ public class AuditFileCacheProviderSpool implements Runnable {
             String spoolFilePerms = StringUtils.defaultIfEmpty(StringUtils.trim(
                             MiscUtil.getStringProperty(props, propPrefix + "." + PROP_FILE_SPOOL_PERMS)),
                     "644");
+            String spoolDirPerms = StringUtils.defaultIfEmpty(StringUtils.trim(
+                            MiscUtil.getStringProperty(props, propPrefix + "." + PROP_FILE_SPOOL_DIR_PERMS)),
+                    "755");
             Set<PosixFilePermission> filePermissions = AuditFileUtil.parsePermissions(spoolFilePerms);
+            Set<PosixFilePermission> dirPermissions = AuditFileUtil.parsePermissions(spoolDirPerms);
             logFileNameFormat = MiscUtil.getStringProperty(props,
                     basePropertyName + "." + PROP_FILE_SPOOL_LOCAL_FILE_NAME);
             String archiveFolderProp = MiscUtil.getStringProperty(props,
@@ -174,12 +179,9 @@ public class AuditFileCacheProviderSpool implements Runnable {
             }
             logFolder = new File(logFolderProp);
             if (!logFolder.isDirectory()) {
-                boolean result = logFolder.mkdirs();
-                if (!logFolder.isDirectory() || !result) {
-                    logger.error("File Spool folder not found and can't be created. folder="
-                            + logFolder.getAbsolutePath()
-                            + ", queueName="
-                            + FILE_CACHE_PROVIDER_NAME);
+                AuditFileUtil.createDirectoryWithPermissions(logFolder, dirPermissions);
+                if (!logFolder.isDirectory()) {
+                    logger.error("File Spool folder not found and can't be created. folder={}, queueName={}", logFolder.getAbsolutePath(),  FILE_CACHE_PROVIDER_NAME);
                     return false;
                 }
             }
@@ -199,12 +201,9 @@ public class AuditFileCacheProviderSpool implements Runnable {
                 archiveFolder = new File(archiveFolderProp);
             }
             if (!archiveFolder.isDirectory()) {
-                boolean result = archiveFolder.mkdirs();
-                if (!archiveFolder.isDirectory() || !result) {
-                    logger.error("File Spool archive folder not found and can't be created. folder="
-                            + archiveFolder.getAbsolutePath()
-                            + ", queueName="
-                            + FILE_CACHE_PROVIDER_NAME);
+                AuditFileUtil.createDirectoryWithPermissions(archiveFolder, dirPermissions);
+                if (!archiveFolder.isDirectory()) {
+                    logger.error("File Spool archive folder not found and can't be created. folder={}, queueName={}", archiveFolder.getAbsolutePath(), FILE_CACHE_PROVIDER_NAME);
                     return false;
                 }
             }

--- a/agents-audit/src/main/java/org/apache/ranger/audit/queue/AuditFileCacheProviderSpool.java
+++ b/agents-audit/src/main/java/org/apache/ranger/audit/queue/AuditFileCacheProviderSpool.java
@@ -19,10 +19,12 @@
 
 package org.apache.ranger.audit.queue;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.ranger.audit.model.AuditEventBase;
 import org.apache.ranger.audit.provider.AuditHandler;
 import org.apache.ranger.audit.model.AuthzAuditEvent;
 import org.apache.ranger.audit.provider.MiscUtil;
+import org.apache.ranger.audit.utils.AuditFileUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -39,12 +41,8 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Date;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Properties;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.*;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
@@ -64,6 +62,7 @@ public class AuditFileCacheProviderSpool implements Runnable {
 
     public static final String PROP_FILE_SPOOL_LOCAL_DIR				= "filespool.dir";
     public static final String PROP_FILE_SPOOL_LOCAL_FILE_NAME 			= "filespool.filename.format";
+    public static final String PROP_FILE_SPOOL_PERMS                    = "filespool.perms";
     public static final String PROP_FILE_SPOOL_ARCHIVE_DIR 				= "filespool.archive.dir";
     public static final String PROP_FILE_SPOOL_ARCHIVE_MAX_FILES_COUNT	= "filespool.archive.max.files";
     public static final String PROP_FILE_SPOOL_FILENAME_PREFIX 			= "filespool.file.prefix";
@@ -139,6 +138,10 @@ public class AuditFileCacheProviderSpool implements Runnable {
             // Initial folder and file properties
             String logFolderProp = MiscUtil.getStringProperty(props, propPrefix
                     + "." + PROP_FILE_SPOOL_LOCAL_DIR);
+            String spoolFilePerms = StringUtils.defaultIfEmpty(StringUtils.trim(
+                            MiscUtil.getStringProperty(props, propPrefix + "." + PROP_FILE_SPOOL_PERMS)),
+                    "644");
+            Set<PosixFilePermission> filePermissions = AuditFileUtil.parsePermissions(spoolFilePerms);
             logFileNameFormat = MiscUtil.getStringProperty(props,
                     basePropertyName + "." + PROP_FILE_SPOOL_LOCAL_FILE_NAME);
             String archiveFolderProp = MiscUtil.getStringProperty(props,
@@ -227,6 +230,7 @@ public class AuditFileCacheProviderSpool implements Runnable {
                             + indexFile.getPath());
                     return false;
                 }
+                AuditFileUtil.setPermissions(indexFile, filePermissions);
             }
             logger.info("indexFile=" + indexFile + ", queueName="
                     + FILE_CACHE_PROVIDER_NAME);
@@ -245,6 +249,7 @@ public class AuditFileCacheProviderSpool implements Runnable {
                             + indexDoneFile.getPath());
                     return false;
                 }
+                AuditFileUtil.setPermissions(indexFile, filePermissions);
             }
             logger.info("indexDoneFile=" + indexDoneFile + ", queueName="
                     + FILE_CACHE_PROVIDER_NAME);

--- a/agents-audit/src/main/java/org/apache/ranger/audit/queue/AuditFileQueueSpool.java
+++ b/agents-audit/src/main/java/org/apache/ranger/audit/queue/AuditFileQueueSpool.java
@@ -244,7 +244,7 @@ public class AuditFileQueueSpool implements Runnable {
                             + indexDoneFile.getPath());
                     return false;
                 }
-                AuditFileUtil.setPermissions(indexFile, filePermissions);
+                AuditFileUtil.setPermissions(indexDoneFile, filePermissions);
             }
             logger.info("indexDoneFile=" + indexDoneFile + ", queueName="
                     + FILE_QUEUE_PROVIDER_NAME);

--- a/agents-audit/src/main/java/org/apache/ranger/audit/queue/AuditFileQueueSpool.java
+++ b/agents-audit/src/main/java/org/apache/ranger/audit/queue/AuditFileQueueSpool.java
@@ -19,12 +19,14 @@
 
 package org.apache.ranger.audit.queue;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.ranger.audit.model.AuditEventBase;
 import org.apache.ranger.audit.model.AuditIndexRecord;
 import org.apache.ranger.audit.model.AuthzAuditEvent;
 import org.apache.ranger.audit.model.SPOOL_FILE_STATUS;
 import org.apache.ranger.audit.provider.AuditHandler;
 import org.apache.ranger.audit.provider.MiscUtil;
+import org.apache.ranger.audit.utils.AuditFileUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -41,12 +43,8 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Date;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Properties;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.*;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
@@ -62,6 +60,7 @@ public class AuditFileQueueSpool implements Runnable {
 
     public static final String PROP_FILE_SPOOL_LOCAL_DIR			   = "filespool.dir";
     public static final String PROP_FILE_SPOOL_LOCAL_FILE_NAME 		   = "filespool.filename.format";
+    public static final String PROP_FILE_SPOOL_PERMS                   = "filespool.perms";
     public static final String PROP_FILE_SPOOL_ARCHIVE_DIR 			   = "filespool.archive.dir";
     public static final String PROP_FILE_SPOOL_ARCHIVE_MAX_FILES_COUNT = "filespool.archive.max.files";
     public static final String PROP_FILE_SPOOL_FILENAME_PREFIX 		   = "filespool.file.prefix";
@@ -136,6 +135,10 @@ public class AuditFileQueueSpool implements Runnable {
             // Initial folder and file properties
             String logFolderProp = MiscUtil.getStringProperty(props, propPrefix
                     + "." + PROP_FILE_SPOOL_LOCAL_DIR);
+            String spoolFilePerms = StringUtils.defaultIfEmpty(StringUtils.trim(
+                            MiscUtil.getStringProperty(props, propPrefix + "." + PROP_FILE_SPOOL_PERMS)),
+                    "644");
+            Set<PosixFilePermission> filePermissions = AuditFileUtil.parsePermissions(spoolFilePerms);
             logFileNameFormat = MiscUtil.getStringProperty(props,
                     basePropertyName + "." + PROP_FILE_SPOOL_LOCAL_FILE_NAME);
             String archiveFolderProp = MiscUtil.getStringProperty(props,
@@ -223,6 +226,7 @@ public class AuditFileQueueSpool implements Runnable {
                             + indexFile.getPath());
                     return false;
                 }
+                AuditFileUtil.setPermissions(indexFile, filePermissions);
             }
             logger.info("indexFile=" + indexFile + ", queueName="
                     + FILE_QUEUE_PROVIDER_NAME);
@@ -241,6 +245,7 @@ public class AuditFileQueueSpool implements Runnable {
                             + indexDoneFile.getPath());
                     return false;
                 }
+                AuditFileUtil.setPermissions(indexFile, filePermissions);
             }
             logger.info("indexDoneFile=" + indexDoneFile + ", queueName="
                     + FILE_QUEUE_PROVIDER_NAME);

--- a/agents-audit/src/main/java/org/apache/ranger/audit/queue/AuditFileQueueSpool.java
+++ b/agents-audit/src/main/java/org/apache/ranger/audit/queue/AuditFileQueueSpool.java
@@ -61,6 +61,7 @@ public class AuditFileQueueSpool implements Runnable {
     public static final String PROP_FILE_SPOOL_LOCAL_DIR			   = "filespool.dir";
     public static final String PROP_FILE_SPOOL_LOCAL_FILE_NAME 		   = "filespool.filename.format";
     public static final String PROP_FILE_SPOOL_PERMS                   = "filespool.perms";
+    public static final String PROP_FILE_SPOOL_DIR_PERMS               = "filespool.dir.perms";
     public static final String PROP_FILE_SPOOL_ARCHIVE_DIR 			   = "filespool.archive.dir";
     public static final String PROP_FILE_SPOOL_ARCHIVE_MAX_FILES_COUNT = "filespool.archive.max.files";
     public static final String PROP_FILE_SPOOL_FILENAME_PREFIX 		   = "filespool.file.prefix";
@@ -138,7 +139,11 @@ public class AuditFileQueueSpool implements Runnable {
             String spoolFilePerms = StringUtils.defaultIfEmpty(StringUtils.trim(
                             MiscUtil.getStringProperty(props, propPrefix + "." + PROP_FILE_SPOOL_PERMS)),
                     "644");
+            String spoolDirPerms = StringUtils.defaultIfEmpty(StringUtils.trim(
+                            MiscUtil.getStringProperty(props, propPrefix + "." + PROP_FILE_SPOOL_DIR_PERMS)),
+                    "755");
             Set<PosixFilePermission> filePermissions = AuditFileUtil.parsePermissions(spoolFilePerms);
+            Set<PosixFilePermission> dirPermissions = AuditFileUtil.parsePermissions(spoolDirPerms);
             logFileNameFormat = MiscUtil.getStringProperty(props,
                     basePropertyName + "." + PROP_FILE_SPOOL_LOCAL_FILE_NAME);
             String archiveFolderProp = MiscUtil.getStringProperty(props,
@@ -170,12 +175,9 @@ public class AuditFileQueueSpool implements Runnable {
             }
             logFolder = new File(logFolderProp);
             if (!logFolder.isDirectory()) {
-                boolean result = logFolder.mkdirs();
-                if (!logFolder.isDirectory() || !result) {
-                    logger.error("File Spool folder not found and can't be created. folder="
-                            + logFolder.getAbsolutePath()
-                            + ", queueName="
-                            + FILE_QUEUE_PROVIDER_NAME);
+                AuditFileUtil.createDirectoryWithPermissions(logFolder, dirPermissions);
+                if (!logFolder.isDirectory()) {
+                    logger.error("File Spool folder not found and can't be created. folder={}, queueName={}", logFolder.getAbsolutePath(),  FILE_QUEUE_PROVIDER_NAME);
                     return false;
                 }
             }
@@ -195,12 +197,9 @@ public class AuditFileQueueSpool implements Runnable {
                 archiveFolder = new File(archiveFolderProp);
             }
             if (!archiveFolder.isDirectory()) {
-                boolean result = archiveFolder.mkdirs();
-                if (!archiveFolder.isDirectory() || !result) {
-                    logger.error("File Spool archive folder not found and can't be created. folder="
-                            + archiveFolder.getAbsolutePath()
-                            + ", queueName="
-                            + FILE_QUEUE_PROVIDER_NAME);
+                AuditFileUtil.createDirectoryWithPermissions(archiveFolder, dirPermissions);
+                if (!archiveFolder.isDirectory()) {
+                    logger.error("File Spool archive folder not found and can't be created. folder={}, queueName={}", archiveFolder.getAbsolutePath(), FILE_QUEUE_PROVIDER_NAME);
                     return false;
                 }
             }

--- a/agents-audit/src/main/java/org/apache/ranger/audit/queue/AuditFileSpool.java
+++ b/agents-audit/src/main/java/org/apache/ranger/audit/queue/AuditFileSpool.java
@@ -55,6 +55,7 @@ public class AuditFileSpool implements Runnable {
 	public static final String PROP_FILE_SPOOL_LOCAL_DIR = "filespool.dir";
 	public static final String PROP_FILE_SPOOL_LOCAL_FILE_NAME = "filespool.filename.format";
 	public static final String PROP_FILE_SPOOL_PERMS = "filespool.perms";
+	public static final String PROP_FILE_SPOOL_DIR_PERMS = "filespool.dir.perms";
 	public static final String PROP_FILE_SPOOL_ARCHIVE_DIR = "filespool.archive.dir";
 	public static final String PROP_FILE_SPOOL_ARCHIVE_MAX_FILES_COUNT = "filespool.archive.max.files";
 	public static final String PROP_FILE_SPOOL_FILENAME_PREFIX = "filespool.file.prefix";
@@ -129,7 +130,11 @@ public class AuditFileSpool implements Runnable {
 			String spoolFilePerms = StringUtils.defaultIfEmpty(StringUtils.trim(
 					MiscUtil.getStringProperty(props, propPrefix + "." + PROP_FILE_SPOOL_PERMS)),
 					"644");
+			String spoolDirPerms = StringUtils.defaultIfEmpty(StringUtils.trim(
+							MiscUtil.getStringProperty(props, propPrefix + "." + PROP_FILE_SPOOL_DIR_PERMS)),
+					"755");
 			Set<PosixFilePermission> filePermissions = AuditFileUtil.parsePermissions(spoolFilePerms);
+			Set<PosixFilePermission> dirPermissions = AuditFileUtil.parsePermissions(spoolDirPerms);
 			logFileNameFormat = MiscUtil.getStringProperty(props,
 					basePropertyName + "." + PROP_FILE_SPOOL_LOCAL_FILE_NAME);
 			String archiveFolderProp = MiscUtil.getStringProperty(props,
@@ -155,7 +160,7 @@ public class AuditFileSpool implements Runnable {
 			}
 			logFolder = new File(logFolderProp);
 			if (!logFolder.isDirectory()) {
-				logFolder.mkdirs();
+				AuditFileUtil.createDirectoryWithPermissions(logFolder, dirPermissions);
 				if (!logFolder.isDirectory()) {
 					logger.error("File Spool folder not found and can't be created. folder={}, queueName={}", logFolder.getAbsolutePath(),  queueProvider.getName());
 					return false;
@@ -175,7 +180,7 @@ public class AuditFileSpool implements Runnable {
 				archiveFolder = new File(archiveFolderProp);
 			}
 			if (!archiveFolder.isDirectory()) {
-				archiveFolder.mkdirs();
+				AuditFileUtil.createDirectoryWithPermissions(archiveFolder, dirPermissions);
 				if (!archiveFolder.isDirectory()) {
 					logger.error("File Spool archive folder not found and can't be created. folder={}, queueName={}", archiveFolder.getAbsolutePath(), queueProvider.getName());
 					return false;

--- a/agents-audit/src/main/java/org/apache/ranger/audit/queue/AuditFileSpool.java
+++ b/agents-audit/src/main/java/org/apache/ranger/audit/queue/AuditFileSpool.java
@@ -27,21 +27,19 @@ import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Date;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Properties;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.*;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.ranger.audit.model.AuditEventBase;
 import org.apache.ranger.audit.model.AuditIndexRecord;
 import org.apache.ranger.audit.model.SPOOL_FILE_STATUS;
 import org.apache.ranger.audit.provider.AuditHandler;
 import org.apache.ranger.audit.provider.MiscUtil;
+import org.apache.ranger.audit.utils.AuditFileUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -56,6 +54,7 @@ public class AuditFileSpool implements Runnable {
 
 	public static final String PROP_FILE_SPOOL_LOCAL_DIR = "filespool.dir";
 	public static final String PROP_FILE_SPOOL_LOCAL_FILE_NAME = "filespool.filename.format";
+	public static final String PROP_FILE_SPOOL_PERMS = "filespool.perms";
 	public static final String PROP_FILE_SPOOL_ARCHIVE_DIR = "filespool.archive.dir";
 	public static final String PROP_FILE_SPOOL_ARCHIVE_MAX_FILES_COUNT = "filespool.archive.max.files";
 	public static final String PROP_FILE_SPOOL_FILENAME_PREFIX = "filespool.file.prefix";
@@ -127,6 +126,10 @@ public class AuditFileSpool implements Runnable {
 			// Initial folder and file properties
 			String logFolderProp = MiscUtil.getStringProperty(props, propPrefix
 					+ "." + PROP_FILE_SPOOL_LOCAL_DIR);
+			String spoolFilePerms = StringUtils.defaultIfEmpty(StringUtils.trim(
+					MiscUtil.getStringProperty(props, propPrefix + "." + PROP_FILE_SPOOL_PERMS)),
+					"644");
+			Set<PosixFilePermission> filePermissions = AuditFileUtil.parsePermissions(spoolFilePerms);
 			logFileNameFormat = MiscUtil.getStringProperty(props,
 					basePropertyName + "." + PROP_FILE_SPOOL_LOCAL_FILE_NAME);
 			String archiveFolderProp = MiscUtil.getStringProperty(props,
@@ -198,6 +201,7 @@ public class AuditFileSpool implements Runnable {
 					logger.error("Error creating index file. fileName={}", indexDoneFile.getPath());
 					return false;
 				}
+				AuditFileUtil.setPermissions(indexFile, filePermissions);
 			}
 			logger.info("indexFile={}, queueName={}", indexFile, queueProvider.getName());
 
@@ -214,6 +218,7 @@ public class AuditFileSpool implements Runnable {
 					logger.error("Error creating index done file. fileName={}", indexDoneFile.getPath());
 					return false;
 				}
+				AuditFileUtil.setPermissions(indexFile, filePermissions);
 			}
 			logger.info("indexDoneFile={}, queueName={}", indexDoneFile, queueProvider.getName());
 

--- a/agents-audit/src/main/java/org/apache/ranger/audit/queue/AuditFileSpool.java
+++ b/agents-audit/src/main/java/org/apache/ranger/audit/queue/AuditFileSpool.java
@@ -223,7 +223,7 @@ public class AuditFileSpool implements Runnable {
 					logger.error("Error creating index done file. fileName={}", indexDoneFile.getPath());
 					return false;
 				}
-				AuditFileUtil.setPermissions(indexFile, filePermissions);
+				AuditFileUtil.setPermissions(indexDoneFile, filePermissions);
 			}
 			logger.info("indexDoneFile={}, queueName={}", indexDoneFile, queueProvider.getName());
 

--- a/agents-audit/src/main/java/org/apache/ranger/audit/utils/AuditFileUtil.java
+++ b/agents-audit/src/main/java/org/apache/ranger/audit/utils/AuditFileUtil.java
@@ -6,6 +6,8 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.FileAttribute;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.util.Set;
@@ -30,6 +32,12 @@ public class AuditFileUtil {
             symbolic.append((value & 1) != 0 ? "x" : "-");
         }
         return PosixFilePermissions.fromString(symbolic.toString());
+    }
+
+    public static void createDirectoryWithPermissions(File dir, Set<PosixFilePermission> perms) throws Exception {
+        FileAttribute<Set<PosixFilePermission>> attr = PosixFilePermissions.asFileAttribute(perms);
+        Path path = dir.toPath();
+        Files.createDirectories(path, attr);
     }
 
 }

--- a/agents-audit/src/main/java/org/apache/ranger/audit/utils/AuditFileUtil.java
+++ b/agents-audit/src/main/java/org/apache/ranger/audit/utils/AuditFileUtil.java
@@ -38,6 +38,7 @@ public class AuditFileUtil {
         FileAttribute<Set<PosixFilePermission>> attr = PosixFilePermissions.asFileAttribute(perms);
         Path path = dir.toPath();
         Files.createDirectories(path, attr);
+        Files.setPosixFilePermissions(path, perms);
     }
 
 }

--- a/agents-audit/src/main/java/org/apache/ranger/audit/utils/AuditFileUtil.java
+++ b/agents-audit/src/main/java/org/apache/ranger/audit/utils/AuditFileUtil.java
@@ -1,0 +1,35 @@
+package org.apache.ranger.audit.utils;
+
+import org.apache.commons.lang.StringUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Set;
+
+public class AuditFileUtil {
+
+    public static void setPermissions(File file, Set<PosixFilePermission> perms) throws IOException {
+        Path path = file.toPath();
+        Files.setPosixFilePermissions(path, perms);
+        }
+
+    public static Set<PosixFilePermission> parsePermissions(String permStr) {
+        if (StringUtils.length(permStr) != 3) {
+            throw new IllegalArgumentException("The permission string must consist of 3 digits, for example '755'");
+        }
+        StringBuilder symbolic = new StringBuilder();
+        for (int i = 0; i < 3; i++) {
+            char c = permStr.charAt(i);
+            int value = c - '0';
+            symbolic.append((value & 4) != 0 ? "r" : "-");
+            symbolic.append((value & 2) != 0 ? "w" : "-");
+            symbolic.append((value & 1) != 0 ? "x" : "-");
+        }
+        return PosixFilePermissions.fromString(symbolic.toString());
+    }
+
+}

--- a/agents-audit/src/test/java/org/apache/ranger/audit/utils/AuditFileUtilTest.java
+++ b/agents-audit/src/test/java/org/apache/ranger/audit/utils/AuditFileUtilTest.java
@@ -5,13 +5,16 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Comparator;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
-public class FileUtilTest {
+public class AuditFileUtilTest {
 
     @Test
     public void testParsePermissions755() {
@@ -62,6 +65,30 @@ public class FileUtilTest {
         File nonExistentFile = new File("nonexistentfile.txt");
         Set<PosixFilePermission> perms = PosixFilePermissions.fromString("rwxr-xr-x");
         AuditFileUtil.setPermissions(nonExistentFile, perms);
+    }
+
+    @Test
+    public void testCreateDirectoryWithPermissions() throws Exception {
+        Path tempBaseDir = Files.createTempDirectory("testCreateDir");
+        try {
+            File newDir = new File(tempBaseDir.toFile(), "newSubDir");
+            Set<PosixFilePermission> expectedPerms = PosixFilePermissions.fromString("rwxr-xr-x");
+
+            AuditFileUtil.createDirectoryWithPermissions(newDir, expectedPerms);
+
+            assertTrue("Directory should exist", newDir.exists());
+
+            Set<PosixFilePermission> actualPerms = Files.getPosixFilePermissions(newDir.toPath());
+            assertEquals("Directory permissions should match expected permissions", expectedPerms, actualPerms);
+        } finally {
+            Files.walk(tempBaseDir)
+                    .sorted(Comparator.reverseOrder())
+                    .forEach(path -> {
+                        try {
+                            Files.delete(path);
+                        } catch (IOException e) {}
+                    });
+        }
     }
 
 }

--- a/agents-audit/src/test/java/org/apache/ranger/audit/utils/AuditFileUtilTest.java
+++ b/agents-audit/src/test/java/org/apache/ranger/audit/utils/AuditFileUtilTest.java
@@ -25,6 +25,22 @@ public class AuditFileUtilTest {
     }
 
     @Test
+    public void testParsePermissions666() {
+        // "666" -> "rw-rw-rw-"
+        Set<PosixFilePermission> actual = AuditFileUtil.parsePermissions("666");
+        Set<PosixFilePermission> expected = PosixFilePermissions.fromString("rw-rw-rw-");
+        assertEquals("Permissions for '666' should be 'rw-rw-rw-'", expected, actual);
+    }
+
+    @Test
+    public void testParsePermissions777() {
+        // "777" -> "rwxrwxrwx"
+        Set<PosixFilePermission> actual = AuditFileUtil.parsePermissions("777");
+        Set<PosixFilePermission> expected = PosixFilePermissions.fromString("rwxrwxrwx");
+        assertEquals("Permissions for '777' should be 'rwxrwxrwx'", expected, actual);
+    }
+
+    @Test
     public void testParsePermissions644() {
         // "644" -> "rw-r--r--"
         Set<PosixFilePermission> actual = AuditFileUtil.parsePermissions("644");
@@ -87,6 +103,33 @@ public class AuditFileUtilTest {
                         try {
                             Files.delete(path);
                         } catch (IOException e) {}
+                    });
+        }
+    }
+
+    @Test
+    public void testCreateDirectoryWithPermissions777() throws Exception {
+        Path tempBaseDir = Files.createTempDirectory("testCreateDir");
+        try {
+            File newDir = new File(tempBaseDir.toFile(), "newSubDir");
+            // "777" corresponds to "rwxrwxrwx"
+            Set<PosixFilePermission> expectedPerms = PosixFilePermissions.fromString("rwxrwxrwx");
+
+            AuditFileUtil.createDirectoryWithPermissions(newDir, expectedPerms);
+
+            assertTrue("Directory should exist", newDir.exists());
+
+            Set<PosixFilePermission> actualPerms = Files.getPosixFilePermissions(newDir.toPath());
+            assertEquals("Directory permissions should match expected permissions", expectedPerms, actualPerms);
+        } finally {
+            Files.walk(tempBaseDir)
+                    .sorted(Comparator.reverseOrder())
+                    .forEach(path -> {
+                        try {
+                            Files.delete(path);
+                        } catch (IOException e) {
+                            // Ignore cleanup exceptions
+                        }
                     });
         }
     }

--- a/agents-audit/src/test/java/org/apache/ranger/audit/utils/FileUtilTest.java
+++ b/agents-audit/src/test/java/org/apache/ranger/audit/utils/FileUtilTest.java
@@ -1,0 +1,67 @@
+package org.apache.ranger.audit.utils;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+
+public class FileUtilTest {
+
+    @Test
+    public void testParsePermissions755() {
+        // "755" -> "rwxr-xr-x"
+        Set<PosixFilePermission> actual = AuditFileUtil.parsePermissions("755");
+        Set<PosixFilePermission> expected = PosixFilePermissions.fromString("rwxr-xr-x");
+        assertEquals("Permissions for '755' should be 'rwxr-xr-x'", expected, actual);
+    }
+
+    @Test
+    public void testParsePermissions644() {
+        // "644" -> "rw-r--r--"
+        Set<PosixFilePermission> actual = AuditFileUtil.parsePermissions("644");
+        Set<PosixFilePermission> expected = PosixFilePermissions.fromString("rw-r--r--");
+        assertEquals("Permissions for '644' should be 'rw-r--r--'", expected, actual);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testParsePermissionsNull() {
+        AuditFileUtil.parsePermissions(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testParsePermissionsShortString() {
+        AuditFileUtil.parsePermissions("75");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testParsePermissionsLongString() {
+        AuditFileUtil.parsePermissions("7555");
+    }
+
+    @Test
+    public void testSetPermissionsOnExistingFile() throws IOException {
+        File tempFile = File.createTempFile("testFile", ".txt");
+        try {
+            Set<PosixFilePermission> expectedPerms = PosixFilePermissions.fromString("rw-r--r--");
+            AuditFileUtil.setPermissions(tempFile, expectedPerms);
+            Set<PosixFilePermission> actualPerms = Files.getPosixFilePermissions(tempFile.toPath());
+                assertEquals("Permissions should be set correctly", expectedPerms, actualPerms);
+        } finally {
+            tempFile.delete();
+        }
+    }
+
+    @Test(expected = NoSuchFileException.class)
+    public void testSetPermissionsOnNonExistentFile() throws IOException {
+        File nonExistentFile = new File("nonexistentfile.txt");
+        Set<PosixFilePermission> perms = PosixFilePermissions.fromString("rwxr-xr-x");
+        AuditFileUtil.setPermissions(nonExistentFile, perms);
+    }
+
+}

--- a/agents-common/src/main/java/org/apache/ranger/plugin/contextenricher/RangerTagEnricher.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/contextenricher/RangerTagEnricher.java
@@ -39,17 +39,8 @@ import org.apache.ranger.plugin.policyengine.RangerPluginContext;
 import org.apache.ranger.plugin.policyengine.RangerResourceTrie;
 import org.apache.ranger.plugin.policyresourcematcher.RangerDefaultPolicyResourceMatcher;
 import org.apache.ranger.plugin.policyresourcematcher.RangerPolicyResourceMatcher;
-import org.apache.ranger.plugin.util.DownloadTrigger;
-import org.apache.ranger.plugin.util.DownloaderTask;
+import org.apache.ranger.plugin.util.*;
 import org.apache.ranger.plugin.service.RangerAuthContext;
-import org.apache.ranger.plugin.util.CachedResourceEvaluators;
-import org.apache.ranger.plugin.util.RangerAccessRequestUtil;
-import org.apache.ranger.plugin.util.RangerCommonConstants;
-import org.apache.ranger.plugin.util.RangerPerfTracer;
-import org.apache.ranger.plugin.util.RangerReadWriteLock;
-import org.apache.ranger.plugin.util.RangerServiceNotFoundException;
-import org.apache.ranger.plugin.util.RangerServiceTagsDeltaUtil;
-import org.apache.ranger.plugin.util.ServiceTags;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -58,6 +49,9 @@ import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.Reader;
 import java.io.Writer;
+import java.nio.file.Files;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -91,6 +85,8 @@ public class RangerTagEnricher extends RangerAbstractContextEnricher {
 	private boolean                            dedupStrings                  = true;
 	private Timer                              tagDownloadTimer;
 	private RangerServiceDefHelper             serviceDefHelper;
+	private Set<PosixFilePermission> cacheFilePerms;
+	private Set<PosixFilePermission>      cacheDirPerms;
 
 	private final BlockingQueue<DownloadTrigger> tagDownloadQueue = new LinkedBlockingQueue<>();
 	private final RangerReadWriteLock            lock             = new RangerReadWriteLock(false);
@@ -112,6 +108,9 @@ public class RangerTagEnricher extends RangerAbstractContextEnricher {
 		dedupStrings               = getBooleanConfig(propertyPrefix + ".dedup.strings", true);
 		disableTrieLookupPrefilter = getBooleanOption(TAG_DISABLE_TRIE_PREFILTER_OPTION, false);
 		serviceDefHelper           = new RangerServiceDefHelper(serviceDef, false);
+
+		String cacheFilePermsString = StringUtils.trim(getConfig(propertyPrefix + ".policy.cache.file.perms", "644"));
+		this.cacheFilePerms = FileUtils.parsePermissions(cacheFilePermsString);
 
 		if (StringUtils.isNotBlank(tagRetrieverClassName)) {
 
@@ -150,7 +149,7 @@ public class RangerTagEnricher extends RangerAbstractContextEnricher {
 				tagRetriever.setPluginContext(getPluginContext());
 				tagRetriever.init(enricherDef.getEnricherOptions());
 
-				tagRefresher = new RangerTagRefresher(tagRetriever, this, -1L, tagDownloadQueue, cacheFile);
+				tagRefresher = new RangerTagRefresher(tagRetriever, this, -1L, tagDownloadQueue, cacheFile, cacheFilePerms);
 				LOG.info("Created RangerTagRefresher Thread(" + tagRefresher.getName() + ")");
 
 				try {
@@ -886,16 +885,17 @@ public class RangerTagEnricher extends RangerAbstractContextEnricher {
 		private long lastKnownVersion;
 		private final BlockingQueue<DownloadTrigger> tagDownloadQueue;
 		private long lastActivationTimeInMillis;
-
+		private final  Set<PosixFilePermission> filePermissions;
 		private final String cacheFile;
 		private boolean      hasProvidedTagsToReceiver;
 
-		RangerTagRefresher(RangerTagRetriever tagRetriever, RangerTagEnricher tagEnricher, long lastKnownVersion, BlockingQueue<DownloadTrigger> tagDownloadQueue, String cacheFile) {
+		RangerTagRefresher(RangerTagRetriever tagRetriever, RangerTagEnricher tagEnricher, long lastKnownVersion, BlockingQueue<DownloadTrigger> tagDownloadQueue, String cacheFile, Set<PosixFilePermission> filePermissions) {
 			this.tagRetriever = tagRetriever;
 			this.tagEnricher = tagEnricher;
 			this.lastKnownVersion = lastKnownVersion;
 			this.tagDownloadQueue = tagDownloadQueue;
 			this.cacheFile = cacheFile;
+			this.filePermissions = filePermissions;
 			setName("RangerTagRefresher(serviceName=" + tagRetriever.getServiceName() + ")-" + getId());
 		}
 
@@ -1099,8 +1099,11 @@ public class RangerTagEnricher extends RangerAbstractContextEnricher {
 					Writer writer = null;
 
 					try {
+						if (!cacheFile.exists()) {
+							Files.createFile(cacheFile.toPath(), PosixFilePermissions.asFileAttribute(this.filePermissions));
+							Files.setPosixFilePermissions(cacheFile.toPath(), this.filePermissions);
+						}
 						writer = new FileWriter(cacheFile);
-
 						JsonUtils.objectToWriter(writer, serviceTags);
 					} catch (Exception excp) {
 						LOG.error("failed to save service-tags to cache file '" + cacheFile.getAbsolutePath() + "'", excp);

--- a/agents-common/src/main/java/org/apache/ranger/plugin/util/FileUtils.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/util/FileUtils.java
@@ -1,0 +1,41 @@
+package org.apache.ranger.plugin.util;
+
+import org.apache.commons.lang.StringUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Set;
+
+public class FileUtils {
+    public static void setPermissions(File file, Set<PosixFilePermission> perms) throws IOException {
+        Path path = file.toPath();
+        Files.setPosixFilePermissions(path, perms);
+    }
+
+    public static Set<PosixFilePermission> parsePermissions(String permStr) {
+        if (StringUtils.length(permStr) != 3) {
+            throw new IllegalArgumentException("The permission string must consist of 3 digits, for example '755'");
+        }
+        StringBuilder symbolic = new StringBuilder();
+        for (int i = 0; i < 3; i++) {
+            char c = permStr.charAt(i);
+            int value = c - '0';
+            symbolic.append((value & 4) != 0 ? "r" : "-");
+            symbolic.append((value & 2) != 0 ? "w" : "-");
+            symbolic.append((value & 1) != 0 ? "x" : "-");
+        }
+        return PosixFilePermissions.fromString(symbolic.toString());
+    }
+
+    public static void createDirectoryWithPermissions(File dir, Set<PosixFilePermission> perms) throws Exception {
+        FileAttribute<Set<PosixFilePermission>> attr = PosixFilePermissions.asFileAttribute(perms);
+        Path path = dir.toPath();
+        Files.createDirectories(path, attr);
+        Files.setPosixFilePermissions(path, perms);
+    }
+}

--- a/agents-common/src/main/java/org/apache/ranger/plugin/util/PolicyRefresher.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/util/PolicyRefresher.java
@@ -19,13 +19,9 @@
 
 package org.apache.ranger.plugin.util;
 
-import java.io.File;
-import java.io.FileFilter;
-import java.io.FileReader;
-import java.io.FileWriter;
-import java.io.Reader;
-import java.io.Writer;
+import java.io.*;
 import java.nio.file.Files;
+import java.nio.file.attribute.FileAttribute;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.text.SimpleDateFormat;
@@ -57,6 +53,7 @@ public class PolicyRefresher extends Thread {
 	private final String                         cacheFileName;
 	private final String                         cacheDir;
 	private final Set<PosixFilePermission>      cacheFilePerms;
+	private final Set<PosixFilePermission>      cacheDirPerms;
 	private final BlockingQueue<DownloadTrigger> policyDownloadQueue = new LinkedBlockingQueue<>();
 	private       Timer                          policyDownloadTimer;
 	private       long                           lastKnownVersion    = -1L;
@@ -79,6 +76,9 @@ public class PolicyRefresher extends Thread {
 		this.cacheDir    = pluginConfig.get(propertyPrefix + ".policy.cache.dir");
 		String cacheFilePermsString = StringUtils.defaultIfEmpty(StringUtils.trim(pluginConfig.get(propertyPrefix + ".policy.cache.file.perms")), "644");
 		this.cacheFilePerms = parsePermissions(cacheFilePermsString);
+
+		String cacheDirPermsString = StringUtils.defaultIfEmpty(StringUtils.trim(pluginConfig.get(propertyPrefix + ".policy.cache.dir.perms")), "755");
+		this.cacheDirPerms = parsePermissions(cacheDirPermsString);
 
 		String appId         = StringUtils.isEmpty(plugIn.getAppId()) ? serviceType : plugIn.getAppId();
 		String cacheFilename = String.format("%s_%s.json", appId, serviceName);
@@ -417,9 +417,10 @@ public class PolicyRefresher extends Thread {
 					cacheFile =  new File(realCacheDirName + File.separator + realCacheFileName);
 				} else {
 					try {
-						cacheDirTmp.mkdirs();
+						FileAttribute<Set<PosixFilePermission>> attr = PosixFilePermissions.asFileAttribute(this.cacheDirPerms);
+						Files.createDirectories(cacheDirTmp.toPath(), attr);
 						cacheFile =  new File(realCacheDirName + File.separator + realCacheFileName);
-					} catch (SecurityException ex) {
+					} catch (SecurityException | IOException ex) {
 						LOG.error("Cannot create cache directory", ex);
 					}
 				}

--- a/agents-common/src/main/java/org/apache/ranger/plugin/util/PolicyRefresher.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/util/PolicyRefresher.java
@@ -75,10 +75,10 @@ public class PolicyRefresher extends Thread {
 		this.serviceName = plugIn.getServiceName();
 		this.cacheDir    = pluginConfig.get(propertyPrefix + ".policy.cache.dir");
 		String cacheFilePermsString = StringUtils.defaultIfEmpty(StringUtils.trim(pluginConfig.get(propertyPrefix + ".policy.cache.file.perms")), "644");
-		this.cacheFilePerms = parsePermissions(cacheFilePermsString);
+		this.cacheFilePerms = FileUtils.parsePermissions(cacheFilePermsString);
 
 		String cacheDirPermsString = StringUtils.defaultIfEmpty(StringUtils.trim(pluginConfig.get(propertyPrefix + ".policy.cache.dir.perms")), "755");
-		this.cacheDirPerms = parsePermissions(cacheDirPermsString);
+		this.cacheDirPerms = FileUtils.parsePermissions(cacheDirPermsString);
 
 		String appId         = StringUtils.isEmpty(plugIn.getAppId()) ? serviceType : plugIn.getAppId();
 		String cacheFilename = String.format("%s_%s.json", appId, serviceName);
@@ -417,10 +417,9 @@ public class PolicyRefresher extends Thread {
 					cacheFile =  new File(realCacheDirName + File.separator + realCacheFileName);
 				} else {
 					try {
-						FileAttribute<Set<PosixFilePermission>> attr = PosixFilePermissions.asFileAttribute(this.cacheDirPerms);
-						Files.createDirectories(cacheDirTmp.toPath(), attr);
+						FileUtils.createDirectoryWithPermissions(cacheDirTmp, cacheDirPerms);
 						cacheFile =  new File(realCacheDirName + File.separator + realCacheFileName);
-					} catch (SecurityException | IOException ex) {
+					} catch (Exception ex) {
 						LOG.error("Cannot create cache directory", ex);
 					}
 				}
@@ -441,6 +440,7 @@ public class PolicyRefresher extends Thread {
 				try {
 					if (!cacheFile.exists()) {
 						Files.createFile(cacheFile.toPath(), PosixFilePermissions.asFileAttribute(this.cacheFilePerms));
+						Files.setPosixFilePermissions(cacheFile.toPath(), this.cacheFilePerms);
 					}
 					writer = new FileWriter(cacheFile);
 					JsonUtils.objectToWriter(writer, policies);
@@ -469,7 +469,14 @@ public class PolicyRefresher extends Thread {
 					if (RangerPerfTracer.isPerfTraceEnabled(PERF_POLICYENGINE_INIT_LOG)) {
 						perf = RangerPerfTracer.getPerfTracer(PERF_POLICYENGINE_INIT_LOG, "PolicyRefresher.saveToCache(serviceName=" + serviceName + ")");
 					}
-
+					try {
+						if (!backupCacheFile.exists()) {
+							Files.createFile(backupCacheFile.toPath(), PosixFilePermissions.asFileAttribute(this.cacheFilePerms));
+							Files.setPosixFilePermissions(backupCacheFile.toPath(), this.cacheFilePerms);
+						}
+					} catch (Exception excp) {
+						LOG.error("failed to save policies to cache file '" + backupCacheFile.getAbsolutePath() + "'", excp);
+					}
 					try (Writer writer = new FileWriter(backupCacheFile)) {
 						JsonUtils.objectToWriter(writer, policies);
 					} catch (Exception excp) {
@@ -571,20 +578,5 @@ public class PolicyRefresher extends Thread {
 		if(LOG.isDebugEnabled()) {
 			LOG.debug("<== PolicyRefresher(serviceName=" + serviceName + ").loadRoles()");
 		}
-	}
-
-	private Set<PosixFilePermission> parsePermissions(String permStr) {
-		if (StringUtils.length(permStr) != 3) {
-			throw new IllegalArgumentException("The permission string must consist of 3 digits, for example '755'");
-		}
-		StringBuilder symbolic = new StringBuilder();
-		for (int i = 0; i < 3; i++) {
-			char c = permStr.charAt(i);
-			int value = c - '0';
-			symbolic.append((value & 4) != 0 ? "r" : "-");
-			symbolic.append((value & 2) != 0 ? "w" : "-");
-			symbolic.append((value & 1) != 0 ? "x" : "-");
-		}
-		return PosixFilePermissions.fromString(symbolic.toString());
 	}
 }

--- a/agents-common/src/main/java/org/apache/ranger/plugin/util/PolicyRefresher.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/util/PolicyRefresher.java
@@ -25,11 +25,11 @@ import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.Reader;
 import java.io.Writer;
+import java.nio.file.Files;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Timer;
+import java.util.*;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 
@@ -56,6 +56,7 @@ public class PolicyRefresher extends Thread {
 	private final long                           pollingIntervalMs;
 	private final String                         cacheFileName;
 	private final String                         cacheDir;
+	private final Set<PosixFilePermission>      cacheFilePerms;
 	private final BlockingQueue<DownloadTrigger> policyDownloadQueue = new LinkedBlockingQueue<>();
 	private       Timer                          policyDownloadTimer;
 	private       long                           lastKnownVersion    = -1L;
@@ -76,6 +77,8 @@ public class PolicyRefresher extends Thread {
 		this.serviceType = plugIn.getServiceType();
 		this.serviceName = plugIn.getServiceName();
 		this.cacheDir    = pluginConfig.get(propertyPrefix + ".policy.cache.dir");
+		String cacheFilePermsString = StringUtils.defaultIfEmpty(StringUtils.trim(pluginConfig.get(propertyPrefix + ".policy.cache.file.perms")), "644");
+		this.cacheFilePerms = parsePermissions(cacheFilePermsString);
 
 		String appId         = StringUtils.isEmpty(plugIn.getAppId()) ? serviceType : plugIn.getAppId();
 		String cacheFilename = String.format("%s_%s.json", appId, serviceName);
@@ -434,8 +437,10 @@ public class PolicyRefresher extends Thread {
 				}
 
 				Writer writer = null;
-	
 				try {
+					if (!cacheFile.exists()) {
+						Files.createFile(cacheFile.toPath(), PosixFilePermissions.asFileAttribute(this.cacheFilePerms));
+					}
 					writer = new FileWriter(cacheFile);
 					JsonUtils.objectToWriter(writer, policies);
 		        } catch (Exception excp) {
@@ -565,5 +570,20 @@ public class PolicyRefresher extends Thread {
 		if(LOG.isDebugEnabled()) {
 			LOG.debug("<== PolicyRefresher(serviceName=" + serviceName + ").loadRoles()");
 		}
+	}
+
+	private Set<PosixFilePermission> parsePermissions(String permStr) {
+		if (StringUtils.length(permStr) != 3) {
+			throw new IllegalArgumentException("The permission string must consist of 3 digits, for example '755'");
+		}
+		StringBuilder symbolic = new StringBuilder();
+		for (int i = 0; i < 3; i++) {
+			char c = permStr.charAt(i);
+			int value = c - '0';
+			symbolic.append((value & 4) != 0 ? "r" : "-");
+			symbolic.append((value & 2) != 0 ? "w" : "-");
+			symbolic.append((value & 1) != 0 ? "x" : "-");
+		}
+		return PosixFilePermissions.fromString(symbolic.toString());
 	}
 }

--- a/agents-common/src/main/java/org/apache/ranger/plugin/util/RangerRolesProvider.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/util/RangerRolesProvider.java
@@ -32,8 +32,12 @@ import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.Reader;
 import java.io.Writer;
+import java.nio.file.Files;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.util.Date;
 import java.util.HashSet;
+import java.util.Set;
 
 
 public class RangerRolesProvider {
@@ -48,6 +52,8 @@ public class RangerRolesProvider {
 	private final String            cacheFileName;
 	private final String			cacheFileNamePrefix;
 	private final String            cacheDir;
+	private final Set<PosixFilePermission> cacheFilePerms;
+	private final Set<PosixFilePermission>      cacheDirPerms;
 	private final boolean           disableCacheIfServiceNotFound;
 
 	private long	lastActivationTimeInMillis;
@@ -78,6 +84,11 @@ public class RangerRolesProvider {
 		this.cacheDir = cacheDir;
 		String propertyPrefix = config.getPropertyPrefix();
 		disableCacheIfServiceNotFound = config.getBoolean(propertyPrefix + ".disable.cache.if.servicenotfound", true);
+		String cacheFilePermsString = StringUtils.defaultIfEmpty(StringUtils.trim(config.get(propertyPrefix + ".policy.cache.file.perms")), "644");
+		this.cacheFilePerms = FileUtils.parsePermissions(cacheFilePermsString);
+
+		String cacheDirPermsString = StringUtils.defaultIfEmpty(StringUtils.trim(config.get(propertyPrefix + ".policy.cache.dir.perms")), "755");
+		this.cacheDirPerms = FileUtils.parsePermissions(cacheDirPermsString);
 
 		if (LOG.isDebugEnabled()) {
 			LOG.debug("<== RangerRolesProvider(serviceName=" + serviceName + ").RangerRolesProvider()");
@@ -275,9 +286,9 @@ public class RangerRolesProvider {
 					cacheFile =  new File(cacheDir + File.separator + cacheFileName);
 				} else {
 					try {
-						cacheDirTmp.mkdirs();
+						FileUtils.createDirectoryWithPermissions(cacheDirTmp, cacheDirPerms);
 						cacheFile =  new File(cacheDir + File.separator + cacheFileName);
-					} catch (SecurityException ex) {
+					} catch (Exception ex) {
 						LOG.error("Cannot create cache directory", ex);
 					}
 				}
@@ -294,6 +305,10 @@ public class RangerRolesProvider {
 				Writer writer = null;
 
 				try {
+					if (!cacheFile.exists()) {
+						Files.createFile(cacheFile.toPath(), PosixFilePermissions.asFileAttribute(this.cacheFilePerms));
+						Files.setPosixFilePermissions(cacheFile.toPath(), this.cacheFilePerms);
+					}
 					writer = new FileWriter(cacheFile);
 					JsonUtils.objectToWriter(writer, roles);
 		        } catch (Exception excp) {


### PR DESCRIPTION
**Enforced File Permissions:**
The patches add configurable file permission settings for audit spool files and cache files. By introducing properties like filespool.perms (defaulting to “644”).
**Controlled Directory Creation:**
With the introduction of filespool.dir.perms and policy.cache.dir.perms (defaulting to “755”), directories are now created using NIO.2’s Files.createDirectories() along with explicit POSIX permissions. 