### PR TITLE
[ADPS-1117] Implement client side for fetching resource mappings

### DIFF
--- a/agents-common/src/main/java/org/apache/ranger/admin/client/AbstractRangerAdminClient.java
+++ b/agents-common/src/main/java/org/apache/ranger/admin/client/AbstractRangerAdminClient.java
@@ -24,6 +24,7 @@ import com.google.gson.GsonBuilder;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.ranger.plugin.model.RangerRole;
+import org.apache.ranger.plugin.model.ResourceMappingDiffs;
 import org.apache.ranger.plugin.util.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -118,6 +119,11 @@ public abstract class AbstractRangerAdminClient implements RangerAdminClient {
 
     @Override
     public RangerUserStore getUserStoreIfUpdated(long lastKnownUserStoreVersion, long lastActivationTimeInMillis) throws Exception {
+        return null;
+    }
+
+    @Override
+    public ResourceMappingDiffs getResourceMappingDiffs(String sourceService, String targetService, Long diffId) throws Exception {
         return null;
     }
 

--- a/agents-common/src/main/java/org/apache/ranger/admin/client/RangerAdminClient.java
+++ b/agents-common/src/main/java/org/apache/ranger/admin/client/RangerAdminClient.java
@@ -22,6 +22,7 @@
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.ranger.plugin.model.RangerRole;
+import org.apache.ranger.plugin.model.ResourceMappingDiffs;
 import org.apache.ranger.plugin.util.GrantRevokeRequest;
 import org.apache.ranger.plugin.util.GrantRevokeRoleRequest;
 import org.apache.ranger.plugin.util.RangerRoles;
@@ -64,4 +65,5 @@ public interface RangerAdminClient {
 
 	RangerUserStore getUserStoreIfUpdated(long lastKnownUserStoreVersion, long lastActivationTimeInMillis) throws Exception;
 
+	ResourceMappingDiffs getResourceMappingDiffs(String sourceService, String targetService, Long diffId) throws Exception;
 }

--- a/agents-common/src/main/java/org/apache/ranger/admin/client/RangerAdminRESTClient.java
+++ b/agents-common/src/main/java/org/apache/ranger/admin/client/RangerAdminRESTClient.java
@@ -22,7 +22,15 @@
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.sun.jersey.api.client.ClientResponse;
-
+import java.io.UnsupportedEncodingException;
+import java.security.PrivilegedExceptionAction;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.core.Cookie;
+import javax.ws.rs.core.NewCookie;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.AccessControlException;
 import org.apache.hadoop.security.UserGroupInformation;
@@ -32,18 +40,22 @@ import org.apache.ranger.audit.provider.MiscUtil;
 import org.apache.ranger.authorization.hadoop.config.RangerPluginConfig;
 import org.apache.ranger.authorization.utils.StringUtil;
 import org.apache.ranger.plugin.model.RangerRole;
-import org.apache.ranger.plugin.util.*;
+import org.apache.ranger.plugin.model.ResourceMappingDiffs;
+import org.apache.ranger.plugin.util.GrantRevokeRequest;
+import org.apache.ranger.plugin.util.GrantRevokeRoleRequest;
+import org.apache.ranger.plugin.util.JsonUtilsV2;
+import org.apache.ranger.plugin.util.RangerCommonConstants;
+import org.apache.ranger.plugin.util.RangerPluginCapability;
+import org.apache.ranger.plugin.util.RangerRESTClient;
+import org.apache.ranger.plugin.util.RangerRESTUtils;
+import org.apache.ranger.plugin.util.RangerRoles;
+import org.apache.ranger.plugin.util.RangerServiceNotFoundException;
+import org.apache.ranger.plugin.util.RangerUserStore;
+import org.apache.ranger.plugin.util.ServicePolicies;
+import org.apache.ranger.plugin.util.ServiceTags;
+import org.apache.ranger.plugin.util.URLEncoderUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.servlet.http.HttpServletResponse;
-import javax.ws.rs.core.Cookie;
-import javax.ws.rs.core.NewCookie;
-import java.io.UnsupportedEncodingException;
-import java.security.PrivilegedExceptionAction;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 public class RangerAdminRESTClient extends AbstractRangerAdminClient {
 	private static final Logger LOG = LoggerFactory.getLogger(RangerAdminRESTClient.class);
@@ -1001,6 +1013,57 @@ public class RangerAdminRESTClient extends AbstractRangerAdminClient {
 		}
 
 		return ret;
+	}
+
+	@Override
+	public ResourceMappingDiffs getResourceMappingDiffs(String sourceService, String targetService, Long diffId) throws Exception {
+		if(LOG.isDebugEnabled()) {
+			LOG.debug("==> RangerAdminRESTClient.getResourceMappingDiffs({}, {}, {})", sourceService, targetService, diffId);
+		}
+
+		UserGroupInformation user = MiscUtil.getUGILoginUser();
+		Cookie sessionId = this.sessionId;
+
+		Map<String, String> queryParams = new HashMap<>();
+		if (diffId != null) {
+			queryParams.put(RangerRESTUtils.REST_PARAM_DIFF_ID, String.valueOf(diffId));
+		}
+		String relativeURL = String.format("/resource-mappings/%s/%s/diffs/new", sourceService, targetService);
+
+		final ClientResponse response;
+		if (isKerberosEnabled(user)) {
+			if (LOG.isDebugEnabled()) {
+				LOG.debug("getResourceMappingDiffs as user {}", user);
+			}
+			response = MiscUtil.executePrivilegedAction((PrivilegedExceptionAction<ClientResponse>) () -> {
+				try {
+					return restClient.get(relativeURL, queryParams, sessionId);
+				} catch (Exception e) {
+					LOG.error("Failed to get response", e);
+				}
+
+				return null;
+			});
+		} else {
+			response = restClient.get(relativeURL, queryParams, sessionId);
+		}
+
+		checkAndResetSessionCookie(response);
+
+		ResourceMappingDiffs diffs;
+		if (response != null && response.getStatus() == HttpServletResponse.SC_OK) {
+			diffs = JsonUtilsV2.readResponse(response, ResourceMappingDiffs.class);
+		} else {
+			RESTResponse resp = RESTResponse.fromClientResponse(response);
+			LOG.error("Error getting resource mappings. Response={}", resp);
+			throw new Exception(resp.getMessage());
+		}
+
+		if(LOG.isDebugEnabled()) {
+            LOG.debug("<== RangerAdminRESTClient.getResourceMappingDiffs({}, {}, {})", sourceService, targetService, diffId);
+		}
+
+		return diffs;
 	}
 
 	private void checkAndResetSessionCookie(ClientResponse response) {

--- a/agents-common/src/main/java/org/apache/ranger/plugin/mapping/BaseResourceMappingFetcher.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/mapping/BaseResourceMappingFetcher.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.plugin.mapping;
+
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.ranger.admin.client.RangerAdminClient;
+import org.apache.ranger.plugin.model.ResourceMappingDiff;
+import org.apache.ranger.plugin.model.ResourceMappingDiffs;
+
+public abstract class BaseResourceMappingFetcher implements ResourceMappingFetcher {
+    private final RangerAdminClient adminClient;
+    private final ScheduledExecutorService executor;
+    private final ResourceMappingStore mappingStore;
+    private final String sourceService;
+    private final String targetService;
+    private final long refreshInterval;
+    private final long commitInterval;
+
+    private final AtomicBoolean isStarted = new AtomicBoolean(false);
+    private volatile Long lastHandledDiffId;
+
+    public BaseResourceMappingFetcher(RangerAdminClient adminClient,
+                                      ScheduledExecutorService executor,
+                                      ResourceMappingStore mappingStore,
+                                      long refreshInterval,
+                                      long commitInterval,
+                                      String sourceService,
+                                      String targetService) {
+        this.adminClient = adminClient;
+        this.sourceService = sourceService;
+        this.targetService = targetService;
+        this.executor = executor;
+        this.mappingStore = mappingStore;
+        this.refreshInterval = refreshInterval;
+        this.commitInterval = commitInterval;
+    }
+
+    @Override
+    public void start() {
+        if (isStarted.compareAndSet(false, true)) {
+            lastHandledDiffId = mappingStore.getLastCommitId().orElse(null);
+            if (lastHandledDiffId == null) {
+                initialFetch();
+            }
+
+            executor.scheduleAtFixedRate(
+                this::fetchDiffs, 0L, refreshInterval, TimeUnit.MILLISECONDS);
+
+            executor.scheduleAtFixedRate(
+                this::commitDiffId, 0L, commitInterval, TimeUnit.MILLISECONDS);
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        executor.shutdown();
+    }
+
+    protected void initialFetch() {
+        fetchDiffs();
+    }
+
+    private void fetchDiffs() {
+        try {
+            ResourceMappingDiffs diffs = adminClient.getResourceMappingDiffs(
+                sourceService,
+                targetService,
+                lastHandledDiffId
+            );
+
+            diffs.getDiffs().forEach(this::handle);
+        } catch (Exception e) {
+            handleDiffApplyError(e);
+        }
+    }
+
+    private void commitDiffId() {
+        if (lastHandledDiffId != null) {
+            try {
+                mappingStore.commit(lastHandledDiffId);
+            } catch (Exception e) {
+                handleCommitError(e);
+            }
+        }
+    }
+
+    private void handle(ResourceMappingDiff diff) {
+        applyDiff(diff);
+        lastHandledDiffId = diff.getId();
+    }
+
+    protected abstract void applyDiff(ResourceMappingDiff diff);
+
+    protected abstract void handleDiffApplyError(Exception error);
+
+    protected abstract void handleCommitError(Exception error);
+}

--- a/agents-common/src/main/java/org/apache/ranger/plugin/mapping/ResourceMappingFetcher.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/mapping/ResourceMappingFetcher.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.plugin.mapping;
+
+public interface ResourceMappingFetcher extends AutoCloseable {
+    void start();
+}

--- a/agents-common/src/main/java/org/apache/ranger/plugin/mapping/ResourceMappingStore.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/mapping/ResourceMappingStore.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.plugin.mapping;
+
+import java.util.Optional;
+
+public interface ResourceMappingStore {
+    void commit(long commitId) throws Exception;
+
+    Optional<Long> getLastCommitId();
+}

--- a/agents-common/src/main/java/org/apache/ranger/plugin/model/ResourceMapping.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/model/ResourceMapping.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.ranger.view;
+package org.apache.ranger.plugin.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -23,11 +23,11 @@ import java.io.Serializable;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class VXResourceMapping implements Serializable {
+public class ResourceMapping implements Serializable {
     private final String name;
     private final String location;
 
-    public VXResourceMapping(String name, String location) {
+    public ResourceMapping(String name, String location) {
         this.name = name;
         this.location = location;
     }

--- a/agents-common/src/main/java/org/apache/ranger/plugin/model/ResourceMappingDiff.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/model/ResourceMappingDiff.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.ranger.view;
+package org.apache.ranger.plugin.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -23,18 +23,18 @@ import java.io.Serializable;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class VXResourceMappingDiff implements Serializable {
-    private final VXResourceMapping oldEntity;
-    private final VXResourceMapping newEntity;
+public class ResourceMappingDiff implements Serializable {
+    private final ResourceMapping oldEntity;
+    private final ResourceMapping newEntity;
     private final String entityType;
     private final String diffType;
     private final long id;
     private final String sourceService;
     private final String targetService;
 
-    public VXResourceMappingDiff(
-        VXResourceMapping oldEntity,
-        VXResourceMapping newEntity,
+    public ResourceMappingDiff(
+        ResourceMapping oldEntity,
+        ResourceMapping newEntity,
         String entityType,
         String diffType,
         long id,
@@ -50,11 +50,11 @@ public class VXResourceMappingDiff implements Serializable {
         this.targetService = targetService;
     }
 
-    public VXResourceMapping getOldEntity() {
+    public ResourceMapping getOldEntity() {
         return oldEntity;
     }
 
-    public VXResourceMapping getNewEntity() {
+    public ResourceMapping getNewEntity() {
         return newEntity;
     }
 

--- a/agents-common/src/main/java/org/apache/ranger/plugin/model/ResourceMappingDiffs.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/model/ResourceMappingDiffs.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.ranger.view;
+package org.apache.ranger.plugin.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -24,14 +24,14 @@ import java.util.List;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class VXResourceMappingDiffs implements Serializable {
-    private final List<VXResourceMappingDiff> diffs;
+public class ResourceMappingDiffs implements Serializable {
+    private final List<ResourceMappingDiff> diffs;
 
-    public VXResourceMappingDiffs(List<VXResourceMappingDiff> diffs) {
+    public ResourceMappingDiffs(List<ResourceMappingDiff> diffs) {
         this.diffs = diffs;
     }
 
-    public List<VXResourceMappingDiff> getDiffs() {
+    public List<ResourceMappingDiff> getDiffs() {
         return diffs;
     }
 }

--- a/agents-common/src/main/java/org/apache/ranger/plugin/service/ResourceMappingChainedPlugin.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/service/ResourceMappingChainedPlugin.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.plugin.service;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
+import org.apache.ranger.plugin.model.RangerPolicy;
+import org.apache.ranger.plugin.policyengine.RangerAccessRequest;
+import org.apache.ranger.plugin.policyengine.RangerAccessResult;
+
+public abstract class ResourceMappingChainedPlugin extends RangerChainedPlugin {
+    protected ResourceMappingChainedPlugin(RangerBasePlugin rootPlugin,
+                                           String serviceType,
+                                           String serviceName) {
+        super(rootPlugin, serviceType, serviceName);
+    }
+
+    @Override
+    public RangerAccessResult evalRowFilterPolicies(RangerAccessRequest request) {
+        List<RangerAccessResult> results = toChainedRequests(request)
+            .stream()
+            .map(req -> plugin.evalRowFilterPolicies(req, null))
+            .collect(Collectors.toList());
+        return reduceAccessResults(request, this::handleRowFilterResult, results);
+    }
+
+    @Override
+    public RangerAccessResult evalDataMaskPolicies(RangerAccessRequest request) {
+        List<RangerAccessResult> results = toChainedRequests(request)
+            .stream()
+            .map(req -> plugin.evalDataMaskPolicies(req, null))
+            .collect(Collectors.toList());
+        return reduceAccessResults(request, this::handleDataMaskResult, results);
+    }
+
+    @Override
+    public Collection<RangerAccessResult> isAccessAllowed(Collection<RangerAccessRequest> requests) {
+        List<RangerAccessRequest> mappedRequests = requests.stream()
+            .map(this::toChainedRequests)
+            .flatMap(Collection::stream)
+            .collect(Collectors.toList());
+
+        return plugin.isAccessAllowed(mappedRequests);
+    }
+
+    @Override
+    public RangerAccessResult isAccessAllowed(RangerAccessRequest request) {
+        List<RangerAccessRequest> chainedRequests = toChainedRequests(request);
+        if (chainedRequests.size() == 1) {
+            return plugin.isAccessAllowed(chainedRequests.get(0));
+        }
+
+        return reduceAccessResults(
+            request, plugin.isAccessAllowed(chainedRequests)
+        );
+    }
+
+    protected abstract List<RangerAccessRequest> toChainedRequests(RangerAccessRequest request);
+
+    protected RangerAccessResult getAllowedResult(RangerAccessRequest request) {
+        RangerAccessResult rangerAccessResult =
+            new RangerAccessResult(RangerPolicy.POLICY_TYPE_ACCESS, serviceName, null, request);
+        rangerAccessResult.setIsAccessDetermined(true);
+        rangerAccessResult.setIsAllowed(true);
+        return rangerAccessResult;
+    }
+
+    protected RangerAccessResult reduceAccessResults(RangerAccessRequest request,
+                                                     Collection<RangerAccessResult> results) {
+
+        return reduceAccessResults(request, (acc, req) -> {}, results);
+    }
+
+    protected void handleRowFilterResult(RangerAccessResult finalResult, RangerAccessResult partialResult) {
+        if (partialResult.getPolicyType() == RangerPolicy.POLICY_TYPE_ROWFILTER) {
+            Optional.ofNullable(partialResult.getFilterExpr())
+                .ifPresent(finalResult::setFilterExpr);
+        }
+    }
+
+    protected void handleDataMaskResult(RangerAccessResult finalResult, RangerAccessResult partialResult) {
+        if (partialResult.getPolicyType() != RangerPolicy.POLICY_TYPE_DATAMASK) {
+            return;
+        }
+
+        Optional.ofNullable(partialResult.getMaskType())
+            .ifPresent(finalResult::setMaskType);
+
+        Optional.ofNullable(partialResult.getMaskCondition())
+            .ifPresent(finalResult::setMaskCondition);
+
+        Optional.ofNullable(partialResult.getMaskedValue())
+            .ifPresent(finalResult::setMaskedValue);
+    }
+
+    protected RangerAccessResult reduceAccessResults(RangerAccessRequest request,
+                                                     BiConsumer<RangerAccessResult, RangerAccessResult> resultHandler,
+                                                     Collection<RangerAccessResult> results) {
+
+        RangerAccessResult allowedResult = getAllowedResult(request);
+        for (RangerAccessResult accessResult : results) {
+            if (accessResult.getIsAccessDetermined() && !accessResult.getIsAllowed()) {
+                return accessResult;
+            }
+
+            resultHandler.accept(allowedResult, accessResult);
+        }
+        return allowedResult;
+    }
+}

--- a/agents-common/src/main/java/org/apache/ranger/plugin/util/RangerRESTUtils.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/util/RangerRESTUtils.java
@@ -87,6 +87,8 @@ public class RangerRESTUtils {
 
 	public static final String REST_PARAM_CAPABILITIES   = "pluginCapabilities";
 
+	public static final String REST_PARAM_DIFF_ID   = "diffId";
+
 	public static String hostname;
 
 	static {

--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -128,6 +128,12 @@
         </dependency>
         <dependency>
             <groupId>org.apache.ranger</groupId>
+            <artifactId>ranger-hive-chained-plugin-base</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.ranger</groupId>
             <artifactId>ranger-hive-plugin</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>

--- a/hive-agent/src/main/java/org/apache/ranger/authorization/hive/authorizer/HiveAccessType.java
+++ b/hive-agent/src/main/java/org/apache/ranger/authorization/hive/authorizer/HiveAccessType.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.authorization.hive.authorizer;
+
+public enum HiveAccessType {
+    NONE,
+    CREATE,
+    ALTER,
+    DROP,
+    LOCK,
+    SELECT,
+    UPDATE,
+    USE,
+    READ,
+    WRITE,
+    ALL,
+    REPLADMIN,
+    SERVICEADMIN,
+    TEMPUDFADMIN,
+    RWSTORAGE
+}

--- a/hive-agent/src/main/java/org/apache/ranger/authorization/hive/authorizer/HiveObjectType.java
+++ b/hive-agent/src/main/java/org/apache/ranger/authorization/hive/authorizer/HiveObjectType.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.authorization.hive.authorizer;
+
+public enum HiveObjectType {
+    NONE,
+    DATABASE,
+    TABLE,
+    VIEW,
+    PARTITION,
+    COLUMN,
+    FUNCTION,
+    URI,
+    SERVICE_NAME,
+    GLOBAL
+}

--- a/hive-agent/src/main/java/org/apache/ranger/authorization/hive/authorizer/RangerHiveAuthorizer.java
+++ b/hive-agent/src/main/java/org/apache/ranger/authorization/hive/authorizer/RangerHiveAuthorizer.java
@@ -3280,8 +3280,6 @@ public class RangerHiveAuthorizer extends RangerHiveAuthorizerBase {
 	}
 }
 
-enum HiveObjectType { NONE, DATABASE, TABLE, VIEW, PARTITION, COLUMN, FUNCTION, URI, SERVICE_NAME, GLOBAL };
-enum HiveAccessType { NONE, CREATE, ALTER, DROP, LOCK, SELECT, UPDATE, USE, READ, WRITE, ALL, REPLADMIN, SERVICEADMIN, TEMPUDFADMIN, RWSTORAGE };
 
 class HiveObj {
 	String databaseName;

--- a/knox-agent/src/main/java/org/apache/ranger/admin/client/RangerAdminJersey2RESTClient.java
+++ b/knox-agent/src/main/java/org/apache/ranger/admin/client/RangerAdminJersey2RESTClient.java
@@ -127,7 +127,7 @@ public class RangerAdminJersey2RESTClient extends AbstractRangerAdminClient {
 		String url = configURLs.get(this.lastKnownActiveUrlIndex);
 		_isSSL = isSsl(url);
 		LOG.info("Init params: " + String.format("Base URL[%s], SSL Config filename[%s], ServiceName=[%s], SupportsPolicyDeltas=[%s], ConfigURLs=[%s]", url, _sslConfigFileName, _serviceName, _supportsPolicyDeltas, _supportsTagDeltas, configURLs));
-		
+
 		_client = getClient();
 		_client.property(ClientProperties.CONNECT_TIMEOUT, _restClientConnTimeOutMs);
 		_client.property(ClientProperties.READ_TIMEOUT, _restClientReadTimeOutMs);
@@ -198,7 +198,7 @@ public class RangerAdminJersey2RESTClient extends AbstractRangerAdminClient {
 		Response response = get(queryParams, relativeURL);
 
 		int httpResponseCode = response == null ? -1 : response.getStatus();
-		
+
 		switch(httpResponseCode) {
 		case -1:
 			LOG.warn("Unexpected: Null response from policy server while granting access! Returning null!");
@@ -234,7 +234,7 @@ public class RangerAdminJersey2RESTClient extends AbstractRangerAdminClient {
 		Response response = get(queryParams, relativeURL);
 
 		int httpResponseCode = response == null ? -1 : response.getStatus();
-		
+
 		switch(httpResponseCode) {
 		case -1:
 			LOG.warn("Unexpected: Null response from policy server while granting access! Returning null!");
@@ -388,7 +388,7 @@ public class RangerAdminJersey2RESTClient extends AbstractRangerAdminClient {
 			.registerTypeAdapter(Date.class, new GsonUnixDateDeserializer())
 			.create();
 	}
-	
+
 	Client getClient() {
 		Client result = _client;
 		if(result == null) {
@@ -404,7 +404,7 @@ public class RangerAdminJersey2RESTClient extends AbstractRangerAdminClient {
 	}
 
 	Client buildClient() {
-		
+
 		if (_isSSL) {
 			if (_sslContext == null) {
 				RangerSslHelper sslHelper = new RangerSslHelper(_sslConfigFileName);
@@ -416,7 +416,7 @@ public class RangerAdminJersey2RESTClient extends AbstractRangerAdminClient {
 						return session.getPeerHost().equals(urlHostName);
 					}
 				};
-			}				
+			}
 			_client = ClientBuilder.newBuilder()
 					.sslContext(_sslContext)
 					.hostnameVerifier(_hv)
@@ -426,7 +426,7 @@ public class RangerAdminJersey2RESTClient extends AbstractRangerAdminClient {
 		if(_client == null) {
 			_client = ClientBuilder.newClient();
 		}
-		
+
 		return _client;
 	}
 

--- a/pom.xml
+++ b/pom.xml
@@ -845,6 +845,7 @@
                 <module>ranger-examples</module>
                 <module>ranger-hbase-plugin-shim</module>
                 <module>ranger-hdfs-plugin-shim</module>
+                <module>ranger-hive-chained-plugin-base</module>
                 <module>ranger-hive-plugin-shim</module>
                 <module>ranger-kafka-plugin-shim</module>
                 <module>ranger-kms-plugin-shim</module>
@@ -898,6 +899,7 @@
                 <module>credentialbuilder</module>
                 <module>hdfs-agent</module>
                 <module>ranger-hdfs-plugin-shim</module>
+                <module>ranger-hive-chained-plugin-base</module>
                 <module>ranger-plugin-classloader</module>
                 <module>ranger-util</module>
                 <module>resource-mapping-manager</module>
@@ -982,6 +984,7 @@
                 <module>agents-installer</module>
                 <module>credentialbuilder</module>
                 <module>plugin-ozone</module>
+                <module>ranger-hive-chained-plugin-base</module>
                 <module>ranger-ozone-plugin-shim</module>
                 <module>ranger-plugin-classloader</module>
                 <module>ranger-util</module>
@@ -1176,6 +1179,7 @@
                 <module>ranger-examples</module>
                 <module>ranger-hbase-plugin-shim</module>
                 <module>ranger-hdfs-plugin-shim</module>
+                <module>ranger-hive-chained-plugin-base</module>
                 <module>ranger-hive-plugin-shim</module>
                 <module>ranger-kafka-plugin-shim</module>
                 <module>ranger-kms-plugin-shim</module>

--- a/ranger-hive-chained-plugin-base/pom.xml
+++ b/ranger-hive-chained-plugin-base/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.ranger</groupId>
+        <artifactId>ranger</artifactId>
+        <version>2.6.0</version>
+    </parent>
+
+    <artifactId>ranger-hive-chained-plugin-base</artifactId>
+    <packaging>jar</packaging>
+    <name>Hive Chained Security Plugin Base</name>
+
+    <properties>
+        <lombok.version>1.18.32</lombok.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.ranger</groupId>
+            <artifactId>ranger-hive-plugin</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>${lombok.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- Test -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>${junit.jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-pmd-plugin</artifactId>
+                <version>${maven.pmd.plugin.version}</version>
+                <configuration>
+                    <includeTests>false</includeTests>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/ranger-hive-chained-plugin-base/src/main/java/org/apache/ranger/hive/chained/mapping/HiveEntity.java
+++ b/ranger-hive-chained-plugin-base/src/main/java/org/apache/ranger/hive/chained/mapping/HiveEntity.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.hive.chained.mapping;
+
+import java.util.Arrays;
+import java.util.List;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import org.apache.ranger.authorization.hive.authorizer.HiveObjectType;
+
+@Data
+@RequiredArgsConstructor
+public class HiveEntity {
+    private final List<String> nameSegments;
+    private final HiveObjectType type;
+
+    public HiveEntity(String fullName, HiveObjectType type) {
+        this.nameSegments = toNameSegments(fullName);
+        this.type = type;
+    }
+
+    public String fullName() {
+        return String.join(".", nameSegments);
+    }
+
+    private List<String> toNameSegments(String fullName) {
+        return Arrays.asList(fullName.split("\\."));
+    }
+}

--- a/ranger-hive-chained-plugin-base/src/main/java/org/apache/ranger/hive/chained/mapping/HiveMappingFetcher.java
+++ b/ranger-hive-chained-plugin-base/src/main/java/org/apache/ranger/hive/chained/mapping/HiveMappingFetcher.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.hive.chained.mapping;
+
+import static org.apache.ranger.hive.chained.plugin.HiveChainedPlugin.HIVE_SERVICE_TYPE;
+
+import java.util.Objects;
+import java.util.concurrent.Executors;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.ranger.admin.client.RangerAdminClient;
+import org.apache.ranger.authorization.hive.authorizer.HiveObjectType;
+import org.apache.ranger.plugin.mapping.BaseResourceMappingFetcher;
+import org.apache.ranger.plugin.model.ResourceMapping;
+import org.apache.ranger.plugin.model.ResourceMappingDiff;
+
+@Slf4j
+public class HiveMappingFetcher extends BaseResourceMappingFetcher {
+
+    enum HiveEntityDiffType {
+        CREATE,
+        UPDATE,
+        DELETE
+    }
+
+    private final HiveResourceMappingStore mappingStore;
+
+    public HiveMappingFetcher(
+        RangerAdminClient adminClient,
+        HiveResourceMappingStore mappingStore,
+        long refreshInterval,
+        long mappingsFlushInterval,
+        String targetService
+    ) {
+        super(
+            adminClient,
+            Executors.newSingleThreadScheduledExecutor(),
+            mappingStore,
+            refreshInterval,
+            mappingsFlushInterval,
+            HIVE_SERVICE_TYPE,
+            targetService
+        );
+        this.mappingStore = mappingStore;
+    }
+
+    public void applyDiff(ResourceMappingDiff diff) {
+        switch (HiveEntityDiffType.valueOf(diff.getDiffType())) {
+            case CREATE:
+                handleCreateEntity(diff);
+                return;
+            case UPDATE:
+                handleUpdateEntity(diff);
+                return;
+            case DELETE:
+                handleDeleteEntity(diff);
+        }
+    }
+
+    @Override
+    protected void handleDiffApplyError(Exception error) {
+        log.error("Failed to apply resource mapping changes", error);
+    }
+
+    @Override
+    protected void handleCommitError(Exception error) {
+        log.error("Failed to commit resource mapping changes", error);
+    }
+
+    private void handleCreateEntity(ResourceMappingDiff diff) {
+        if (diff.getOldEntity() == null) {
+            throw new IllegalArgumentException("Wrong diff for create event: " + diff);
+        }
+
+        putEntity(diff.getOldEntity(), diff.getEntityType());
+    }
+
+    private void handleUpdateEntity(ResourceMappingDiff diff) {
+        if (diff.getOldEntity() == null || diff.getNewEntity() == null) {
+            throw new IllegalArgumentException("Wrong diff for update event: " + diff);
+        }
+
+        if (Objects.equals(diff.getOldEntity().getLocation(), diff.getNewEntity().getLocation())) {
+            putEntity(diff.getNewEntity(), diff.getEntityType());
+            return;
+        }
+
+        mappingStore.move(
+            diff.getOldEntity().getLocation(),
+            diff.getNewEntity().getLocation(),
+            toHiveEntity(diff.getNewEntity(), diff.getEntityType())
+        );
+    }
+
+    private void handleDeleteEntity(ResourceMappingDiff diff) {
+        if (diff.getOldEntity() == null) {
+            throw new IllegalArgumentException("Wrong diff for delete event: " + diff);
+        }
+
+        mappingStore.remove(diff.getOldEntity().getLocation());
+    }
+
+    private void putEntity(ResourceMapping mapping, String entityType) {
+        HiveEntity hiveEntity = toHiveEntity(mapping, entityType);
+        mappingStore.put(mapping.getLocation(), hiveEntity);
+    }
+
+    private HiveEntity toHiveEntity(ResourceMapping mapping, String entityType) {
+        return new HiveEntity(
+            mapping.getName(),
+            HiveObjectType.valueOf(entityType)
+        );
+    }
+}

--- a/ranger-hive-chained-plugin-base/src/main/java/org/apache/ranger/hive/chained/mapping/HiveResourceMappingStore.java
+++ b/ranger-hive-chained-plugin-base/src/main/java/org/apache/ranger/hive/chained/mapping/HiveResourceMappingStore.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.hive.chained.mapping;
+
+import java.util.Optional;
+import org.apache.ranger.plugin.mapping.ResourceMappingStore;
+
+public interface HiveResourceMappingStore extends ResourceMappingStore {
+    Optional<HiveEntity> get(String path);
+
+    void put(String path, HiveEntity value);
+
+    void remove(String path);
+
+    void move(String oldPath, String newPath, HiveEntity newValue);
+}

--- a/ranger-hive-chained-plugin-base/src/main/java/org/apache/ranger/hive/chained/mapping/TrieHiveResourceMappingStore.java
+++ b/ranger-hive-chained-plugin-base/src/main/java/org/apache/ranger/hive/chained/mapping/TrieHiveResourceMappingStore.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.hive.chained.mapping;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.apache.ranger.hive.chained.mapping.persist.FileSystemMappingsPersistentStore;
+import org.apache.ranger.hive.chained.mapping.persist.HiveMappings;
+import org.apache.ranger.hive.chained.mapping.persist.TriePersistentStore;
+import org.apache.ranger.hive.chained.trie.DefaultTrie;
+import org.apache.ranger.hive.chained.trie.SynchronizedTrie;
+import org.apache.ranger.hive.chained.trie.Trie;
+import org.apache.ranger.hive.chained.trie.TrieVisitor;
+
+@RequiredArgsConstructor
+public class TrieHiveResourceMappingStore implements HiveResourceMappingStore {
+
+    private static final Trie.Key<String> ROOT_KEY = new Trie.Key<>(new String[0]);
+    private static final String ROOT_PATH = "/";
+    private static final String PATH_DELIMITER = "/";
+
+    private final Trie<String, HiveEntity> pathPrefixes;
+    private final TriePersistentStore persistentStore;
+    private final Long loadedVersion;
+
+    public TrieHiveResourceMappingStore() {
+        this.pathPrefixes = SynchronizedTrie.wrap(new DefaultTrie<>());
+
+        this.persistentStore = null;
+        this.loadedVersion = null;
+    }
+
+    public TrieHiveResourceMappingStore(String mappingsLocation) throws IOException {
+        this.persistentStore = new FileSystemMappingsPersistentStore(mappingsLocation);
+        this.pathPrefixes = SynchronizedTrie.wrap(new DefaultTrie<>());
+
+        this.loadedVersion = loadMappings().orElse(null);
+    }
+
+    @Override
+    public Optional<HiveEntity> get(String path) {
+        List<HiveEntity> prefixValues = pathPrefixes.getPrefixValues(pathToTrieKey(path));
+        return Optional.of(prefixValues)
+            .filter(entities -> !entities.isEmpty())
+            .map(entities -> entities.get(entities.size() - 1));
+    }
+
+    @Override
+    public void put(String path, HiveEntity value) {
+        pathPrefixes.put(pathToTrieKey(path), value);
+    }
+
+    @Override
+    public void remove(String path) {
+        pathPrefixes.remove(pathToTrieKey(path));
+    }
+
+    @Override
+    public void move(String oldPath, String newPath, HiveEntity newValue) {
+        pathPrefixes.move(pathToTrieKey(oldPath), pathToTrieKey(newPath), newValue);
+    }
+
+    @Override
+    public void commit(long commitId) throws Exception {
+        if (persistentStore == null) {
+            return;
+        }
+
+        try (TrieVisitor<String, HiveEntity> visitor = persistentStore.getTrieWriter(commitId)) {
+            pathPrefixes.accept(visitor);
+        }
+    }
+
+    @Override
+    public Optional<Long> getLastCommitId() {
+        return Optional.ofNullable(loadedVersion);
+    }
+
+    public static Trie.Key<String> pathToTrieKey(String path) {
+        if (path == null) {
+            return null;
+        }
+
+        String formattedPath = path.trim();
+        if (path.equals(ROOT_PATH)) {
+            return ROOT_KEY;
+        }
+
+        int startTrimPosition = 0;
+        if (formattedPath.startsWith(PATH_DELIMITER)) {
+            ++startTrimPosition;
+        }
+
+        int endTrimPosition = formattedPath.length();
+        if (formattedPath.endsWith(PATH_DELIMITER)) {
+            --endTrimPosition;
+        }
+
+        return new Trie.Key<>(formattedPath
+            .substring(startTrimPosition, endTrimPosition)
+            .split(PATH_DELIMITER));
+    }
+
+    public static String trieKeyToPath(Trie.Key<String> key) {
+        return PATH_DELIMITER + String.join(PATH_DELIMITER, key.getSegments());
+    }
+
+    private Optional<Long> loadMappings() throws IOException {
+        if (persistentStore == null) {
+            return Optional.empty();
+        }
+
+        Optional<HiveMappings> mappings = persistentStore.getMappings();
+        mappings.ifPresent(
+            hiveMappings -> hiveMappings.getMappings().forEach(this::put)
+        );
+
+        return mappings.map(HiveMappings::getVersion);
+    }
+}

--- a/ranger-hive-chained-plugin-base/src/main/java/org/apache/ranger/hive/chained/mapping/persist/FileSystemMappingsPersistentStore.java
+++ b/ranger-hive-chained-plugin-base/src/main/java/org/apache/ranger/hive/chained/mapping/persist/FileSystemMappingsPersistentStore.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.hive.chained.mapping.persist;
+
+import static org.apache.ranger.hive.chained.mapping.TrieHiveResourceMappingStore.trieKeyToPath;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.apache.ranger.hive.chained.mapping.HiveEntity;
+import org.apache.ranger.hive.chained.trie.Trie;
+import org.apache.ranger.hive.chained.trie.TrieVisitor;
+
+@RequiredArgsConstructor
+public class FileSystemMappingsPersistentStore implements TriePersistentStore {
+    @Getter
+    private final String mappingsLocation;
+    private final MappingSerializer mappingSerializer;
+
+    public FileSystemMappingsPersistentStore(String mappingsLocation) {
+        this.mappingsLocation = mappingsLocation;
+        this.mappingSerializer = new JsonMappingSerializer();
+    }
+
+    @Override
+    public Optional<HiveMappings> getMappings() throws IOException {
+        Path mappingsPath = Paths.get(mappingsLocation);
+        if (!Files.exists(mappingsPath)) {
+            return Optional.empty();
+        }
+
+        long version;
+        Map<String, HiveEntity> mappings = new HashMap<>();
+
+        try (BufferedReader reader = Files.newBufferedReader(mappingsPath, StandardCharsets.UTF_8)) {
+            version = Long.parseLong(reader.readLine());
+            reader.lines()
+                .forEach(line -> mappingSerializer.deserialize(line, mappings));
+        }
+
+        return Optional.of(new HiveMappings(version, mappings));
+    }
+
+    @Override
+    public TrieVisitor<String, HiveEntity> getTrieWriter(long version) throws IOException {
+        return new TrieFileWriter(mappingsLocation, mappingSerializer, version);
+    }
+
+    public static class TrieFileWriter implements TrieVisitor<String, HiveEntity> {
+        private final BufferedWriter writer;
+        private final MappingSerializer mappingSerializer;
+
+        public TrieFileWriter(
+            String filePath,
+            MappingSerializer mappingSerializer,
+            long version
+        ) throws IOException {
+            this.writer = new BufferedWriter(new FileWriter(filePath));
+            this.mappingSerializer = mappingSerializer;
+
+            writer.write(String.valueOf(version));
+            writer.newLine();
+        }
+
+        @Override
+        public void acceptNode(Trie.Key<String> key, HiveEntity value) throws IOException {
+            String serialize = mappingSerializer.serialize(trieKeyToPath(key), value);
+            writer.write(serialize);
+            writer.newLine();
+        }
+
+        @Override
+        public void close() throws IOException {
+            writer.close();
+        }
+    }
+}

--- a/ranger-hive-chained-plugin-base/src/main/java/org/apache/ranger/hive/chained/mapping/persist/HiveMappings.java
+++ b/ranger-hive-chained-plugin-base/src/main/java/org/apache/ranger/hive/chained/mapping/persist/HiveMappings.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.hive.chained.mapping.persist;
+
+import java.util.Map;
+import lombok.Data;
+import org.apache.ranger.hive.chained.mapping.HiveEntity;
+
+@Data
+public class HiveMappings {
+    private final long version;
+
+    private final Map<String, HiveEntity> mappings;
+}

--- a/ranger-hive-chained-plugin-base/src/main/java/org/apache/ranger/hive/chained/mapping/persist/JsonMappingSerializer.java
+++ b/ranger-hive-chained-plugin-base/src/main/java/org/apache/ranger/hive/chained/mapping/persist/JsonMappingSerializer.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.hive.chained.mapping.persist;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Map;
+import lombok.Getter;
+import org.apache.ranger.authorization.hive.authorizer.HiveObjectType;
+import org.apache.ranger.hive.chained.mapping.HiveEntity;
+
+public class JsonMappingSerializer implements MappingSerializer {
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Override
+    public String serialize(String path, HiveEntity entity) {
+        try {
+            return mapper.writeValueAsString(new Mapping(path, entity.fullName(), entity.getType()));
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Error serializing mapping", e);
+        }
+    }
+
+    @Override
+    public void deserialize(String value, Map<String, HiveEntity> accumulator) {
+        try {
+            Mapping mapping = mapper.readValue(value, Mapping.class);
+            accumulator.put(mapping.path, new HiveEntity(mapping.name, mapping.type));
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Error deserializing mapping", e);
+        }
+    }
+
+    @Getter
+    private static class Mapping {
+        private final String path;
+        private final String name;
+        private final HiveObjectType type;
+
+        @JsonCreator
+        public Mapping(
+            @JsonProperty(value = "path")
+            String path,
+            @JsonProperty(value = "name")
+            String name,
+            @JsonProperty(value = "type")
+            HiveObjectType type) {
+            this.path = path;
+            this.name = name;
+            this.type = type;
+        }
+    }
+
+}

--- a/ranger-hive-chained-plugin-base/src/main/java/org/apache/ranger/hive/chained/mapping/persist/MappingSerializer.java
+++ b/ranger-hive-chained-plugin-base/src/main/java/org/apache/ranger/hive/chained/mapping/persist/MappingSerializer.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.hive.chained.mapping.persist;
+
+import java.util.Map;
+import org.apache.ranger.hive.chained.mapping.HiveEntity;
+
+public interface MappingSerializer {
+    String serialize(String path, HiveEntity entity);
+
+    void deserialize(String value, Map<String, HiveEntity> accumulator);
+}

--- a/ranger-hive-chained-plugin-base/src/main/java/org/apache/ranger/hive/chained/mapping/persist/TriePersistentStore.java
+++ b/ranger-hive-chained-plugin-base/src/main/java/org/apache/ranger/hive/chained/mapping/persist/TriePersistentStore.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.hive.chained.mapping.persist;
+
+import java.io.IOException;
+import java.util.Optional;
+import org.apache.ranger.hive.chained.mapping.HiveEntity;
+import org.apache.ranger.hive.chained.trie.TrieVisitor;
+
+public interface TriePersistentStore {
+    Optional<HiveMappings> getMappings() throws IOException;
+
+    TrieVisitor<String, HiveEntity> getTrieWriter(long version) throws IOException;
+}

--- a/ranger-hive-chained-plugin-base/src/main/java/org/apache/ranger/hive/chained/plugin/HiveChainedPlugin.java
+++ b/ranger-hive-chained-plugin-base/src/main/java/org/apache/ranger/hive/chained/plugin/HiveChainedPlugin.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.hive.chained.plugin;
+
+import static org.apache.ranger.hive.chained.plugin.HiveChainedPluginConfigKeys.MAPPINGS_FILE_LOCATION_DEFAULT;
+import static org.apache.ranger.hive.chained.plugin.HiveChainedPluginConfigKeys.MAPPINGS_FILE_LOCATION_POSTFIX;
+import static org.apache.ranger.hive.chained.plugin.HiveChainedPluginConfigKeys.MAPPINGS_PERSIST_INTERVAL_DEFAULT;
+import static org.apache.ranger.hive.chained.plugin.HiveChainedPluginConfigKeys.MAPPINGS_PERSIST_INTERVAL_POSTFIX;
+import static org.apache.ranger.hive.chained.plugin.HiveChainedPluginConfigKeys.MAPPINGS_REFRESH_INTERVAL_DEFAULT;
+import static org.apache.ranger.hive.chained.plugin.HiveChainedPluginConfigKeys.MAPPINGS_REFRESH_INTERVAL_POSTFIX;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.apache.ranger.admin.client.RangerAdminClient;
+import org.apache.ranger.authorization.hive.authorizer.HiveAccessType;
+import org.apache.ranger.authorization.hive.authorizer.HiveObjectType;
+import org.apache.ranger.authorization.hive.authorizer.RangerHiveAccessRequest;
+import org.apache.ranger.authorization.hive.authorizer.RangerHiveResource;
+import org.apache.ranger.hive.chained.mapping.HiveEntity;
+import org.apache.ranger.hive.chained.mapping.HiveMappingFetcher;
+import org.apache.ranger.hive.chained.mapping.HiveResourceMappingStore;
+import org.apache.ranger.hive.chained.mapping.TrieHiveResourceMappingStore;
+import org.apache.ranger.plugin.mapping.ResourceMappingFetcher;
+import org.apache.ranger.plugin.policyengine.RangerAccessRequest;
+import org.apache.ranger.plugin.policyengine.RangerPluginContext;
+import org.apache.ranger.plugin.policyengine.RangerResourceACLs;
+import org.apache.ranger.plugin.service.RangerBasePlugin;
+import org.apache.ranger.plugin.service.ResourceMappingChainedPlugin;
+
+public abstract class HiveChainedPlugin extends ResourceMappingChainedPlugin {
+    public static final String HIVE_SERVICE_TYPE = "hive";
+
+    private final HiveResourceMappingStore resourceMappingsStore;
+    private final ResourceMappingFetcher resourceMappingFetcher;
+
+    protected HiveChainedPlugin(RangerBasePlugin rootPlugin, String serviceName) throws IOException {
+        super(rootPlugin, HIVE_SERVICE_TYPE, serviceName);
+
+        String mappingsFileLocation = rootPlugin.getConfig().get(
+            rootPlugin.getConfig().getPropertyPrefix()
+                + MAPPINGS_FILE_LOCATION_POSTFIX, MAPPINGS_FILE_LOCATION_DEFAULT);
+        this.resourceMappingsStore = new TrieHiveResourceMappingStore(mappingsFileLocation);
+
+        long refreshInterval = rootPlugin.getConfig().getLong(
+            rootPlugin.getConfig().getPropertyPrefix()
+                + MAPPINGS_REFRESH_INTERVAL_POSTFIX, MAPPINGS_REFRESH_INTERVAL_DEFAULT);
+        long mappingsPersistInterval = rootPlugin.getConfig().getLong(
+            rootPlugin.getConfig().getPropertyPrefix()
+                + MAPPINGS_PERSIST_INTERVAL_POSTFIX, MAPPINGS_PERSIST_INTERVAL_DEFAULT);
+
+        RangerPluginContext pluginContext = rootPlugin.getPluginContext();
+        RangerAdminClient adminClient = Optional.ofNullable(pluginContext.getAdminClient())
+            .orElseGet(() -> pluginContext.createAdminClient(rootPlugin.getConfig()));
+
+        this.resourceMappingFetcher = new HiveMappingFetcher(
+            adminClient,
+            resourceMappingsStore,
+            refreshInterval,
+            mappingsPersistInterval,
+            serviceName
+        );
+    }
+
+    @Override
+    public void init() {
+        super.init();
+
+        resourceMappingFetcher.start();
+    }
+
+    @Override
+    public RangerResourceACLs getResourceACLs(RangerAccessRequest request, Integer policyType) {
+        // currently we don't need to override the root plugins ACLs
+        return null;
+    }
+
+    @Override
+    public RangerResourceACLs getResourceACLs(RangerAccessRequest request) {
+        // currently we don't need to override the root plugins ACLs
+        return null;
+    }
+
+    @Override
+    protected List<RangerAccessRequest> toChainedRequests(RangerAccessRequest request) {
+        return Optional.ofNullable(request)
+            .map(this::getPathFromRequest)
+            .flatMap(resourceMappingsStore::get)
+            .map(entity -> toAccessRequests(entity, request))
+            .orElseGet(Collections::emptyList);
+    }
+
+    protected abstract String getPathFromRequest(RangerAccessRequest request);
+
+    protected abstract List<HiveAccessType> getHiveAccessTypes(RangerAccessRequest request);
+
+    private List<RangerAccessRequest> toAccessRequests(HiveEntity entity, RangerAccessRequest srcRequest) {
+        return getHiveAccessTypes(srcRequest)
+            .stream()
+            .map(accessType -> new RangerHiveAccessRequest(
+                toHiveResource(entity),
+                srcRequest.getUser(),
+                srcRequest.getUserGroups(),
+                srcRequest.getUserRoles(),
+                (String) null,
+                accessType,
+                null,
+                null
+            ))
+            .collect(Collectors.toList());
+    }
+
+    private RangerHiveResource toHiveResource(HiveEntity entity) {
+        List<String> nameSegments = entity.getNameSegments();
+
+        if (entity.getType() == HiveObjectType.DATABASE) {
+            if (nameSegments.size() < 2) {
+                throw new IllegalArgumentException("Wrong db name: " + entity.fullName());
+            }
+            return new RangerHiveResource(entity.getType(), nameSegments.get(1));
+        }
+
+        if (nameSegments.size() < 3) {
+            throw new IllegalArgumentException("Wrong entity name: " + entity.fullName());
+        }
+        return new RangerHiveResource(
+            entity.getType(),
+            nameSegments.get(1),
+            nameSegments.get(2)
+        );
+    }
+}

--- a/ranger-hive-chained-plugin-base/src/main/java/org/apache/ranger/hive/chained/plugin/HiveChainedPluginConfigKeys.java
+++ b/ranger-hive-chained-plugin-base/src/main/java/org/apache/ranger/hive/chained/plugin/HiveChainedPluginConfigKeys.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.hive.chained.plugin;
+
+public class HiveChainedPluginConfigKeys {
+    public static final String MAPPINGS_FILE_LOCATION_POSTFIX = ".chained.plugin.hive.mappings.file.location";
+    public static final String MAPPINGS_FILE_LOCATION_DEFAULT = "/opt/ranger/hive-resource-mappings";
+
+    public static final String MAPPINGS_REFRESH_INTERVAL_POSTFIX = ".chained.plugin.hive.mappings.refresh.interval.ms";
+    public static final long MAPPINGS_REFRESH_INTERVAL_DEFAULT = 30000L;
+
+    public static final String MAPPINGS_PERSIST_INTERVAL_POSTFIX = ".chained.plugin.hive.mappings.file.flush.interval.ms";
+    public static final long MAPPINGS_PERSIST_INTERVAL_DEFAULT = 60000L;
+}

--- a/ranger-hive-chained-plugin-base/src/main/java/org/apache/ranger/hive/chained/trie/DefaultTrie.java
+++ b/ranger-hive-chained-plugin-base/src/main/java/org/apache/ranger/hive/chained/trie/DefaultTrie.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.hive.chained.trie;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class DefaultTrie<K, V> implements Trie<K, V> {
+    private final DefaultTrieNode<K, V> root;
+
+    public DefaultTrie() {
+        this.root = new DefaultTrieNode<>(null, null);
+    }
+
+    @Override
+    public List<V> getPrefixValues(Key<K> key) {
+        return getPrefixNodes(key)
+            .stream()
+            .map(DefaultTrieNode::getValue)
+            .collect(Collectors.toList());
+    }
+
+    @Override
+    public Optional<V> get(Key<K> key) {
+        return getExactNode(key).map(DefaultTrieNode::getValue);
+    }
+
+    @Override
+    public void put(Trie.Key<K> key, V value) {
+        getOrCreateNode(key).setValue(value);
+    }
+
+    @Override
+    public boolean remove(Trie.Key<K> key) {
+        return removeNode(key).isPresent();
+    }
+
+    @Override
+    public boolean move(Trie.Key<K> oldKey, Trie.Key<K> newKey, V newValue) {
+        Optional<DefaultTrieNode<K, V>> node = removeNode(oldKey);
+        if (!node.isPresent()) {
+            return false;
+        }
+
+        DefaultTrieNode<K, V> newNode = getOrCreateNode(newKey);
+        newNode.merge(node.get());
+        if (newValue != null) {
+            newNode.setValue(newValue);
+        }
+        return true;
+    }
+
+    @Override
+    public void accept(TrieVisitor<K, V> visitor) throws Exception {
+        root.accept(visitor);
+    }
+
+    private DefaultTrieNode<K, V> getOrCreateNode(Trie.Key<K> key) {
+        DefaultTrieNode<K, V> iter = root;
+        for (K segment : key.getSegments()) {
+            iter = iter.getOrCreateChild(segment);
+        }
+        return iter;
+    }
+
+    private Optional<DefaultTrieNode<K, V>> removeNode(Trie.Key<K> key) {
+        Optional<DefaultTrieNode<K, V>> maybeNode = getExactNode(key);
+        if (!maybeNode.isPresent()) {
+            return Optional.empty();
+        }
+
+        DefaultTrieNode<K, V> node = maybeNode.get();
+        // physically remove node and parents if needed
+        K previousKey = node.getKey();
+        DefaultTrieNode<K, V> iter = node.getParent();
+        while (iter != null) {
+            iter.removeChild(previousKey);
+            if (!iter.isLeaf()) {
+                break;
+            }
+
+            iter = iter.getParent();
+        }
+
+        return Optional.of(node);
+    }
+
+    private Optional<DefaultTrieNode<K, V>> getExactNode(Trie.Key<K> key) {
+        DefaultTrieNode<K, V> iter = root;
+        for (K segment : key.getSegments()) {
+            Optional<DefaultTrieNode<K, V>> child = iter.getChild(segment);
+            if (!child.isPresent()) {
+                return Optional.empty();
+            }
+
+            iter = child.get();
+        }
+
+        return Optional.ofNullable(iter);
+    }
+
+    private List<DefaultTrieNode<K, V>> getPrefixNodes(Trie.Key<K> key) {
+        List<DefaultTrieNode<K, V>> results = new ArrayList<>();
+
+        DefaultTrieNode<K, V> iter = root;
+        for (K segment : key.getSegments()) {
+            Optional<DefaultTrieNode<K, V>> child = iter.getChild(segment);
+            if (!child.isPresent()) {
+                break;
+            }
+
+            if (child.get().getValue() != null) {
+                results.add(child.get());
+            }
+
+            iter = child.get();
+        }
+
+        return results;
+    }
+}

--- a/ranger-hive-chained-plugin-base/src/main/java/org/apache/ranger/hive/chained/trie/DefaultTrieNode.java
+++ b/ranger-hive-chained-plugin-base/src/main/java/org/apache/ranger/hive/chained/trie/DefaultTrieNode.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.hive.chained.trie;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.Data;
+
+@Data
+public class DefaultTrieNode<K, V> implements Trie.Node<K, V> {
+    private final K key;
+    private final DefaultTrieNode<K, V> parent;
+    private final Map<K, DefaultTrieNode<K, V>> children;
+
+    private volatile V value;
+
+    public DefaultTrieNode(K key, DefaultTrieNode<K, V> parent, V value) {
+        this.key = key;
+        this.value = value;
+        this.parent = parent;
+        this.children = new ConcurrentHashMap<>();
+    }
+
+    public DefaultTrieNode(K key, DefaultTrieNode<K, V> parent) {
+        this(key, parent, null);
+    }
+
+    public void removeChild(K key) {
+        children.remove(key);
+    }
+
+    public Optional<DefaultTrieNode<K, V>> getChild(K key) {
+        DefaultTrieNode<K, V> child = children.get(key);
+        return Optional.ofNullable(child);
+    }
+
+    public boolean isLeaf() {
+        return children.isEmpty();
+    }
+
+    public DefaultTrieNode<K, V> getOrCreateChild(K key) {
+        return children.computeIfAbsent(key, childKey -> new DefaultTrieNode<>(childKey, this));
+    }
+
+    public void merge(DefaultTrieNode<K, V> node) {
+        value = node.value;
+        children.putAll(node.children);
+    }
+
+    @Override
+    public String toString() {
+        return "DefaultTrieNode{" +
+            "key=" + key +
+            ", value=" + value +
+            '}';
+    }
+
+    @Override
+    public void accept(TrieVisitor<K, V> visitor) throws Exception {
+        accept(visitor, new ArrayDeque<>());
+    }
+
+    private void accept(TrieVisitor<K, V> visitor, Deque<K> keySegments) throws Exception {
+        if (key != null) {
+            keySegments.addLast(key);
+        }
+
+        if (value != null) {
+            visitor.acceptNode(
+                new Trie.Key<>(new ArrayList<>(keySegments)),
+                value
+            );
+        }
+
+        for (DefaultTrieNode<K, V> child : children.values()) {
+            child.accept(visitor, keySegments);
+        }
+
+        keySegments.pollLast();
+    }
+}

--- a/ranger-hive-chained-plugin-base/src/main/java/org/apache/ranger/hive/chained/trie/SynchronizedTrie.java
+++ b/ranger-hive-chained-plugin-base/src/main/java/org/apache/ranger/hive/chained/trie/SynchronizedTrie.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.hive.chained.trie;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+public class SynchronizedTrie<K, V> implements Trie<K, V> {
+    private final Trie<K, V> delegate;
+    private final ReadWriteLock lock;
+
+    public SynchronizedTrie(Trie<K, V> delegate) {
+        this.delegate = delegate;
+        this.lock = new ReentrantReadWriteLock();
+    }
+
+    @Override
+    public List<V> getPrefixValues(Key<K> key) {
+        lock.readLock().lock();
+        try {
+            return delegate.getPrefixValues(key);
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    @Override
+    public Optional<V> get(Key<K> key) {
+        lock.readLock().lock();
+        try {
+            return delegate.get(key);
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    @Override
+    public void put(Key<K> key, V value) {
+        lock.writeLock().lock();
+        try {
+            delegate.put(key, value);
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    @Override
+    public boolean remove(Key<K> key) {
+        lock.writeLock().lock();
+        try {
+            return delegate.remove(key);
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    @Override
+    public boolean move(Key<K> oldKey, Key<K> newKey, V newValue) {
+        lock.writeLock().lock();
+        try {
+            return delegate.move(oldKey, newKey, newValue);
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    @Override
+    public void accept(TrieVisitor<K, V> visitor) throws Exception {
+        lock.readLock().lock();
+        try {
+            delegate.accept(visitor);
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    public static <K, V> Trie<K, V> wrap(Trie<K, V> delegate) {
+        return new SynchronizedTrie<>(delegate);
+    }
+}

--- a/ranger-hive-chained-plugin-base/src/main/java/org/apache/ranger/hive/chained/trie/Trie.java
+++ b/ranger-hive-chained-plugin-base/src/main/java/org/apache/ranger/hive/chained/trie/Trie.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.hive.chained.trie;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+
+public interface Trie<K, V> {
+    @Data
+    @RequiredArgsConstructor
+    class Key<K> {
+        private final List<K> segments;
+
+        @SafeVarargs
+        public Key(K... segments) {
+            this.segments = Arrays.asList(segments);
+        }
+    }
+
+    interface Node<K, V> {
+        K getKey();
+
+        V getValue();
+
+        void accept(TrieVisitor<K, V> visitor) throws Exception;
+    }
+
+    List<V> getPrefixValues(Trie.Key<K> key);
+
+    Optional<V> get(Trie.Key<K> key);
+
+    void put(Trie.Key<K> key, V value);
+
+    boolean remove(Trie.Key<K> key);
+
+    boolean move(Trie.Key<K> oldKey, Trie.Key<K> newKey, V newValue);
+
+    void accept(TrieVisitor<K, V> visitor) throws Exception;
+}

--- a/ranger-hive-chained-plugin-base/src/main/java/org/apache/ranger/hive/chained/trie/TrieVisitor.java
+++ b/ranger-hive-chained-plugin-base/src/main/java/org/apache/ranger/hive/chained/trie/TrieVisitor.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.hive.chained.trie;
+
+public interface TrieVisitor<K, V> extends AutoCloseable {
+    void acceptNode(Trie.Key<K> key, V value) throws Exception;
+
+    default void close() throws Exception {
+        // no-op
+    }
+}

--- a/ranger-hive-chained-plugin-base/src/test/java/org/apache/ranger/hive/chained/mapping/HiveMappingFetcherTest.java
+++ b/ranger-hive-chained-plugin-base/src/test/java/org/apache/ranger/hive/chained/mapping/HiveMappingFetcherTest.java
@@ -1,0 +1,201 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.hive.chained.mapping;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.apache.ranger.authorization.hive.authorizer.HiveObjectType;
+import org.apache.ranger.plugin.model.ResourceMapping;
+import org.apache.ranger.plugin.model.ResourceMappingDiff;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class HiveMappingFetcherTest {
+
+    private HiveMappingFetcher mappingFetcher;
+    private MockHiveResourceMappingStore mappingStore;
+
+    @BeforeEach
+    public void setUp() {
+        mappingStore = new MockHiveResourceMappingStore();
+        mappingFetcher = new HiveMappingFetcher(
+            null,
+            mappingStore,
+            -1L,
+            -1L,
+            "test"
+        );
+    }
+
+    private static Stream<HiveObjectType> objectTypesParamSource() {
+        return Stream.of(
+            HiveObjectType.TABLE,
+            HiveObjectType.DATABASE
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource(value = "objectTypesParamSource")
+    public void testApplyCreateTable(HiveObjectType objectType) {
+        ResourceMappingDiff createDiff = newCreateDiff(objectType, "composite.name", "/location");
+        mappingFetcher.applyDiff(createDiff);
+
+        Optional<HiveEntity> maybeEntity = mappingStore.get("/location");
+        assertTrue(maybeEntity.isPresent());
+        assertEquals(Arrays.asList("composite", "name"), maybeEntity.get().getNameSegments());
+        assertEquals(objectType, maybeEntity.get().getType());
+    }
+
+    @ParameterizedTest
+    @MethodSource(value = "objectTypesParamSource")
+    public void testApplyDeleteTable(HiveObjectType objectType) {
+        ResourceMappingDiff createDiff = newCreateDiff(objectType, "complex.name", "/location");
+        mappingFetcher.applyDiff(createDiff);
+        assertTrue(mappingStore.get("/location").isPresent());
+
+        ResourceMappingDiff deleteDiff = newDeleteDiff(objectType, "composite.name2", "/location_2");
+        mappingFetcher.applyDiff(deleteDiff);
+        assertTrue(mappingStore.get("/location").isPresent());
+
+        deleteDiff = newDeleteDiff(objectType, "complex.name", "/location");
+        mappingFetcher.applyDiff(deleteDiff);
+        assertFalse(mappingStore.get("/location").isPresent());
+    }
+
+    @ParameterizedTest
+    @MethodSource(value = "objectTypesParamSource")
+    public void testApplyUpdateTableName(HiveObjectType objectType) {
+        ResourceMappingDiff createDiff = newCreateDiff(objectType, "complex.name", "/location1");
+        mappingFetcher.applyDiff(createDiff);
+        assertTrue(mappingStore.get("/location1").isPresent());
+        assertEquals("complex.name", mappingStore.get("/location1").get().fullName());
+
+        ResourceMappingDiff updateDiff = newTestDiff(
+            HiveMappingFetcher.HiveEntityDiffType.UPDATE,
+            objectType,
+            new ResourceMapping("complex.name", "/location1"),
+            new ResourceMapping("another.name.2", "/location1")
+        );
+        mappingFetcher.applyDiff(updateDiff);
+        assertTrue(mappingStore.get("/location1").isPresent());
+        assertEquals("another.name.2", mappingStore.get("/location1").get().fullName());
+    }
+
+    @ParameterizedTest
+    @MethodSource(value = "objectTypesParamSource")
+    public void testApplyUpdateTableLocation(HiveObjectType objectType) {
+        ResourceMappingDiff createDiff = newCreateDiff(objectType, "complex.name", "/location1");
+        mappingFetcher.applyDiff(createDiff);
+        assertTrue(mappingStore.get("/location1").isPresent());
+        assertEquals("complex.name", mappingStore.get("/location1").get().fullName());
+
+        ResourceMappingDiff updateOnlyLocationDiff = newTestDiff(
+            HiveMappingFetcher.HiveEntityDiffType.UPDATE,
+            objectType,
+            new ResourceMapping("complex.name", "/location1"),
+            new ResourceMapping("complex.name", "/location2")
+        );
+        mappingFetcher.applyDiff(updateOnlyLocationDiff);
+        assertFalse(mappingStore.get("/location1").isPresent());
+        assertTrue(mappingStore.get("/location2").isPresent());
+        assertEquals("complex.name", mappingStore.get("/location2").get().fullName());
+
+        ResourceMappingDiff updateLocationAndNameDiff = newTestDiff(
+            HiveMappingFetcher.HiveEntityDiffType.UPDATE,
+            objectType,
+            new ResourceMapping("complex.name", "/location2"),
+            new ResourceMapping("another.name", "/location3")
+        );
+        mappingFetcher.applyDiff(updateLocationAndNameDiff);
+        assertFalse(mappingStore.get("/location2").isPresent());
+        assertTrue(mappingStore.get("/location3").isPresent());
+        assertEquals("another.name", mappingStore.get("/location3").get().fullName());
+    }
+
+    private ResourceMappingDiff newCreateDiff(HiveObjectType objectType, String name, String location) {
+        return newTestDiff(HiveMappingFetcher.HiveEntityDiffType.CREATE,
+            objectType, new ResourceMapping(name, location), null);
+    }
+
+    private ResourceMappingDiff newDeleteDiff(HiveObjectType objectType, String name, String location) {
+        return newTestDiff(HiveMappingFetcher.HiveEntityDiffType.DELETE,
+            objectType, new ResourceMapping(name, location), null);
+    }
+
+    private ResourceMappingDiff newTestDiff(
+        HiveMappingFetcher.HiveEntityDiffType diffType,
+        HiveObjectType objectType,
+        ResourceMapping oldEntity,
+        ResourceMapping newEntity) {
+        return new ResourceMappingDiff(
+            oldEntity,
+            newEntity,
+            objectType.toString(),
+            diffType.toString(),
+            1L,
+            "hive",
+            "otherService"
+        );
+    }
+
+    private static class MockHiveResourceMappingStore implements HiveResourceMappingStore {
+        private final Map<String, HiveEntity> mappings = new HashMap<>();
+
+        @Override
+        public Optional<HiveEntity> get(String path) {
+            return Optional.ofNullable(mappings.get(path));
+        }
+
+        @Override
+        public void put(String path, HiveEntity value) {
+            mappings.put(path, value);
+        }
+
+        @Override
+        public void remove(String path) {
+            mappings.remove(path);
+        }
+
+        @Override
+        public void move(String oldPath, String newPath, HiveEntity value) {
+            remove(oldPath);
+            put(newPath, value);
+        }
+
+        @Override
+        public void commit(long commitId) {
+            // no-op
+        }
+
+        @Override
+        public Optional<Long> getLastCommitId() {
+            // no-op
+            return Optional.empty();
+        }
+    }
+}

--- a/ranger-hive-chained-plugin-base/src/test/java/org/apache/ranger/hive/chained/mapping/TrieHiveResourceMappingStoreTest.java
+++ b/ranger-hive-chained-plugin-base/src/test/java/org/apache/ranger/hive/chained/mapping/TrieHiveResourceMappingStoreTest.java
@@ -1,0 +1,194 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.hive.chained.mapping;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Optional;
+import org.apache.ranger.authorization.hive.authorizer.HiveObjectType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class TrieHiveResourceMappingStoreTest {
+    private TrieHiveResourceMappingStore mappingStore;
+
+    @BeforeEach
+    public void setUp() {
+        mappingStore = new TrieHiveResourceMappingStore();
+    }
+
+    @Test
+    public void testPutAndGet() {
+        HiveEntity expectedEntity = new HiveEntity("db.table1", HiveObjectType.TABLE);
+        mappingStore.put("/db/table1", expectedEntity);
+
+        assertContains("/db/table1", expectedEntity);
+
+        expectedEntity = new HiveEntity("db.db2", HiveObjectType.DATABASE);
+        mappingStore.put("/db/table1", expectedEntity);
+
+        assertContains("/db/table1", expectedEntity);
+    }
+
+    @Test
+    public void testGetUnknownEntity() {
+        assertNoValue("/db/table1");
+        assertNoValue("/db/table2");
+
+        mappingStore.put("/db/table2", new HiveEntity("db.table1", HiveObjectType.TABLE));
+
+        assertNoValue("/db/table1");
+    }
+
+    @Test
+    public void testGetPrefixEntity() {
+        HiveEntity db = new HiveEntity("db", HiveObjectType.DATABASE);
+        mappingStore.put("/db", db);
+
+        assertContains("/db", db);
+        assertContains("/db/", db);
+        assertContains("/db/1", db);
+        assertContains("/db/table", db);
+        assertContains("/db/table/path", db);
+
+        HiveEntity table = new HiveEntity("table", HiveObjectType.TABLE);
+        mappingStore.put("/db/table", table);
+
+        assertContains("/db/table", table);
+        assertContains("/db/table/path", table);
+        assertContains("/db/table2", db);
+        assertContains("/db/table2/other_path", db);
+        assertNoValue("/db2");
+    }
+
+    @Test
+    public void testRemoveEntity() {
+        HiveEntity db = new HiveEntity("db", HiveObjectType.DATABASE);
+        mappingStore.put("/db", db);
+
+        HiveEntity table = new HiveEntity("table", HiveObjectType.TABLE);
+        mappingStore.put("/db/table", table);
+
+        assertContains("/db/table/some/path", table);
+
+        mappingStore.remove("/db/table");
+        assertContains("/db/table/some/path", db);
+
+        mappingStore.remove("/db");
+        assertNoValue("/db/table/some/path");
+    }
+
+    @Test
+    public void testRemovingBaseEntityRemovesChildren() {
+        HiveEntity db = new HiveEntity("db", HiveObjectType.DATABASE);
+        mappingStore.put("/db", db);
+
+        HiveEntity db2 = new HiveEntity("db2", HiveObjectType.DATABASE);
+        mappingStore.put("/db2", db2);
+
+        HiveEntity table = new HiveEntity("table", HiveObjectType.TABLE);
+        mappingStore.put("/db/table1", table);
+
+        HiveEntity table2 = new HiveEntity("table2", HiveObjectType.TABLE);
+        mappingStore.put("/db/table2", table2);
+
+        HiveEntity table3 = new HiveEntity("table3", HiveObjectType.TABLE);
+        mappingStore.put("/db2/table3", table3);
+
+        HiveEntity subTable = new HiveEntity("subTable", HiveObjectType.TABLE);
+        mappingStore.put("/db/table1/subTable", subTable);
+
+        assertContains("/db", db);
+        assertContains("/db/table1", table);
+        assertContains("/db/table2", table2);
+        assertContains("/db/table1/subTable", subTable);
+        assertContains("/db/table1/subTable/somepath", subTable);
+        assertContains("/db2", db2);
+        assertContains("/db2/table3", table3);
+
+        mappingStore.remove("/db");
+
+        assertNoValue("/db");
+        assertNoValue("/db/table1");
+        assertNoValue("/db/table2");
+        assertNoValue("/db/table1/subTable");
+        assertNoValue("/db/table1/subTable/somepath");
+
+        assertContains("/db2", db2);
+        assertContains("/db2/table3", table3);
+    }
+
+    @Test
+    public void testMoveEntity() {
+        HiveEntity db = new HiveEntity("db", HiveObjectType.DATABASE);
+        mappingStore.put("/db", db);
+
+        HiveEntity db2 = new HiveEntity("db2", HiveObjectType.DATABASE);
+        mappingStore.put("/db2", db2);
+
+        HiveEntity table = new HiveEntity("table", HiveObjectType.TABLE);
+        mappingStore.put("/db/table1", table);
+
+        HiveEntity table2 = new HiveEntity("table2", HiveObjectType.TABLE);
+        mappingStore.put("/db/table2", table2);
+
+        HiveEntity table3 = new HiveEntity("table3", HiveObjectType.TABLE);
+        mappingStore.put("/db2/table3", table3);
+
+        HiveEntity subTable = new HiveEntity("subTable", HiveObjectType.TABLE);
+        mappingStore.put("/db/table1/subTable", subTable);
+
+        assertContains("/db", db);
+        assertContains("/db/table1", table);
+        assertContains("/db/table2", table2);
+        assertContains("/db/table1/subTable", subTable);
+        assertContains("/db/table1/subTable/somepath", subTable);
+        assertContains("/db2", db2);
+        assertContains("/db2/table3", table3);
+
+        mappingStore.move("/db", "/db2", db2);
+
+        assertNoValue("/db");
+        assertNoValue("/db/table1");
+        assertNoValue("/db/table2");
+        assertNoValue("/db/table1/subTable");
+        assertNoValue("/db/table1/subTable/somepath");
+
+        assertContains("/db2", db2);
+        assertContains("/db2/table1", table);
+        assertContains("/db2/table2", table2);
+        assertContains("/db2/table3", table3);
+        assertContains("/db2/table1/subTable", subTable);
+        assertContains("/db2/table1/subTable/somepath", subTable);
+    }
+
+    private void assertContains(String path, HiveEntity expectedEntity) {
+        Optional<HiveEntity> hiveEntity = mappingStore.get(path);
+
+        assertTrue(hiveEntity.isPresent());
+        assertEquals(expectedEntity, hiveEntity.get());
+    }
+
+    private void assertNoValue(String path) {
+        assertFalse(mappingStore.get(path).isPresent());
+    }
+}

--- a/ranger-hive-chained-plugin-base/src/test/java/org/apache/ranger/hive/chained/mapping/persist/FileSystemMappingsPersistentStoreTest.java
+++ b/ranger-hive-chained-plugin-base/src/test/java/org/apache/ranger/hive/chained/mapping/persist/FileSystemMappingsPersistentStoreTest.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.hive.chained.mapping.persist;
+
+import static org.apache.ranger.hive.chained.mapping.TrieHiveResourceMappingStore.pathToTrieKey;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.apache.hadoop.thirdparty.com.google.common.collect.ImmutableMap;
+import org.apache.ranger.authorization.hive.authorizer.HiveObjectType;
+import org.apache.ranger.hive.chained.mapping.HiveEntity;
+import org.apache.ranger.hive.chained.trie.DefaultTrie;
+import org.apache.ranger.hive.chained.trie.TrieVisitor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class FileSystemMappingsPersistentStoreTest {
+    private FileSystemMappingsPersistentStore store;
+    private DefaultTrie<String, HiveEntity> trie;
+
+    private static final Map<String, HiveEntity> TEST_MAPPINGS = ImmutableMap
+        .<String, HiveEntity>builder()
+        .put("/key1", table("table1"))
+        .put("/root/key2", table("table2"))
+        .put("/root/dir", db("db1"))
+        .put("/root/dir/key3", table("table3"))
+        .put("/root/dir/key4", table("table4"))
+        .put("/root/dir/subdir/key5", table("table5"))
+        .put("/root/another/key6", table("table6"))
+        .put("/usr/key7", db("db2"))
+        .build();
+
+    @TempDir
+    protected Path testDir;
+
+    @BeforeEach
+    public void setUp() {
+        Path mappingsFile = testDir.resolve(UUID.randomUUID().toString());
+        store = new FileSystemMappingsPersistentStore(mappingsFile.toString());
+
+        trie = new DefaultTrie<>();
+        initTrie();
+    }
+
+    @Test
+    public void testPersistAndLoad() throws Exception {
+        persist(11L);
+
+        HiveMappings expectedMappings = new HiveMappings(11L, TEST_MAPPINGS);
+        Optional<HiveMappings> mappings = store.getMappings();
+
+        assertTrue(mappings.isPresent());
+        assertEquals(expectedMappings, mappings.get());
+    }
+
+    @Test
+    public void testRewriteFile() throws Exception {
+        persist(1L);
+        persist(2L);
+        persist(3L);
+
+        HiveMappings expectedMappings = new HiveMappings(3L, TEST_MAPPINGS);
+        Optional<HiveMappings> mappings = store.getMappings();
+
+        assertTrue(mappings.isPresent());
+        assertEquals(expectedMappings, mappings.get());
+
+        trie.put(pathToTrieKey("/root/dir/key3"), table("table33"));
+        trie.put(pathToTrieKey("/root/dir/key4"), db("table4"));
+        persist(4L);
+
+        Map<String, HiveEntity> newMappings = new HashMap<>(TEST_MAPPINGS);
+        newMappings.put("/root/dir/key3", table("table33"));
+        newMappings.put("/root/dir/key4", db("table4"));
+        HiveMappings expectedUpdatedMappings = new HiveMappings(4L, newMappings);
+        mappings = store.getMappings();
+
+        assertTrue(mappings.isPresent());
+        assertEquals(expectedUpdatedMappings, mappings.get());
+    }
+
+    @Test
+    public void testPersistTrie() throws Exception {
+        persist(10L);
+
+        String expectedMappings = fileContent(resolveResourcePath("mappings/fs-test-mappings.txt"));
+        String actualMappings = fileContent(store.getMappingsLocation());
+        assertEquals(expectedMappings, actualMappings);
+    }
+
+    private String fileContent(String location) throws Exception {
+        return new String(
+            Files.readAllBytes(Paths.get(location)),
+            StandardCharsets.UTF_8
+        );
+    }
+
+    private String resolveResourcePath(String resourcePath) {
+        URL resource = this.getClass().getClassLoader().getResource(resourcePath);
+        return Optional.ofNullable(resource)
+            .map(URL::getPath)
+            .orElseThrow(() -> new IllegalArgumentException("File not found: " + resourcePath));
+    }
+
+    private void persist(long version) throws Exception {
+        try (TrieVisitor<String, HiveEntity> visitor = store.getTrieWriter(version)) {
+            trie.accept(visitor);
+        }
+    }
+
+    private void initTrie() {
+        TEST_MAPPINGS.forEach((key, val) ->
+            trie.put(pathToTrieKey(key), val)
+        );
+    }
+
+    private static HiveEntity table(String name) {
+        return new HiveEntity(name, HiveObjectType.TABLE);
+    }
+
+    private static HiveEntity db(String name) {
+        return new HiveEntity(name, HiveObjectType.DATABASE);
+    }
+}

--- a/ranger-hive-chained-plugin-base/src/test/java/org/apache/ranger/hive/chained/trie/TrieTest.java
+++ b/ranger-hive-chained-plugin-base/src/test/java/org/apache/ranger/hive/chained/trie/TrieTest.java
@@ -1,0 +1,270 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.hive.chained.trie;
+
+import static org.apache.ranger.hive.chained.mapping.TrieHiveResourceMappingStore.pathToTrieKey;
+import static org.apache.ranger.hive.chained.mapping.TrieHiveResourceMappingStore.trieKeyToPath;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Stream;
+import org.apache.hadoop.thirdparty.com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class TrieTest {
+    private static Stream<Trie<String, String>> triesSource() {
+        return Stream.of(
+            new DefaultTrie<>(),
+            SynchronizedTrie.wrap(new DefaultTrie<>())
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource(value = "triesSource")
+    public void testAdd(Trie<String, String> trie) {
+        Trie.Key<String> key = pathToTrieKey("/root/dir/subdir");
+        trie.put(key, "value");
+
+        assertHasValue(trie, "/root/dir/subdir", "value");
+
+        assertNoValue(trie, "/root/dir");
+        assertNoValue(trie, "/root");
+        assertNoValue(trie, "/");
+    }
+
+    @ParameterizedTest
+    @MethodSource(value = "triesSource")
+    public void testGet(Trie<String, String> trie) {
+        Stream.of(
+            "/root/dir/key1",
+            "/root/dir/subdir/key2",
+            "/other/sub/test/key3",
+            "/key4",
+            "other_key",
+            "q",
+            "/root/dir",
+            "/root",
+            "/other/sub/test"
+        ).forEach(key -> putValueAndCheck(
+            trie, key, UUID.randomUUID().toString()
+        ));
+
+        Stream.of(
+            "/other",
+            "/other/sub",
+            "/unknown_dir",
+            "/key40",
+            "/key5"
+        ).forEach(key -> assertFalse(
+            trie.get(pathToTrieKey(key)).isPresent()
+        ));
+    }
+
+    @ParameterizedTest
+    @MethodSource(value = "triesSource")
+    public void testPut(Trie<String, String> trie) {
+        putValueAndCheck(trie, "/root/dir/subdir", "value");
+        putValueAndCheck(trie, "/root/dir/subdir", "value1");
+        putValueAndCheck(trie, "/root/dir/subdir", "value2");
+        putValueAndCheck(trie, "/root/dir/subdir", "other_value");
+        putValueAndCheck(trie, "/root/dir/subdir", "another_val");
+
+        putValueAndCheck(trie, "/root/dir2/key", "val");
+
+        // recheck another key not affected
+        assertHasValue(trie, "/root/dir/subdir", "another_val");
+    }
+
+    @ParameterizedTest
+    @MethodSource(value = "triesSource")
+    public void testRemove(Trie<String, String> trie) {
+        putValueAndCheck(trie, "/root/subdir/key1", "value1");
+        putValueAndCheck(trie, "/root/subdir/key2", "value2");
+        putValueAndCheck(trie, "/root/subdir/key3", "value2");
+        putValueAndCheck(trie, "/root/key4", "value3");
+        putValueAndCheck(trie, "/key5", "value3");
+
+        trie.remove(pathToTrieKey("/root/subdir/key2"));
+        assertNoValue(trie, "/root/subdir/key2");
+
+        assertHasValue(trie, "/root/subdir/key1", "value1");
+        assertHasValue(trie, "/root/subdir/key3", "value2");
+        assertHasValue(trie, "/root/key4", "value3");
+        assertHasValue(trie, "/key5", "value3");
+
+        trie.remove(pathToTrieKey("/root/subdir"));
+        assertNoValue(trie, "/root/subdir/key2");
+        assertNoValue(trie, "/root/subdir/key1");
+        assertNoValue(trie, "/root/subdir/key3");
+
+        assertHasValue(trie, "/root/key4", "value3");
+        assertHasValue(trie, "/key5", "value3");
+
+        // check has no effect
+        trie.remove(pathToTrieKey("/roo"));
+        assertNoValue(trie, "/root/subdir/key2");
+        assertNoValue(trie, "/root/subdir/key1");
+        assertNoValue(trie, "/root/subdir/key3");
+
+        assertHasValue(trie, "/root/key4", "value3");
+        assertHasValue(trie, "/key5", "value3");
+
+        trie.remove(pathToTrieKey("/root"));
+        assertNoValue(trie, "/root/subdir/key2");
+        assertNoValue(trie, "/root/subdir/key1");
+        assertNoValue(trie, "/root/subdir/key3");
+        assertNoValue(trie, "/root/key4");
+
+        assertHasValue(trie, "/key5", "value3");
+    }
+
+    @ParameterizedTest
+    @MethodSource(value = "triesSource")
+    public void testCleanupAfterRemove(Trie<String, String> trie) {
+        putValueAndCheck(trie, "/root/subdir/key1", "value1");
+
+        trie.remove(pathToTrieKey("/root/subdir/key1"));
+
+        assertNoValue(trie, "/root/subdir/key1");
+        assertNoValue(trie, "/root/subdir");
+        assertNoValue(trie, "/root/");
+    }
+
+    @ParameterizedTest
+    @MethodSource(value = "triesSource")
+    public void testGetPrefix(Trie<String, String> trie) {
+        putValueAndCheck(trie, "/root/subdir", "subdir_val");
+        putValueAndCheck(trie, "/root/subdir/key", "key_val");
+        putValueAndCheck(trie, "/root", "root_val");
+
+        assertHasPrefixValues(trie, "/root/subdir/key/subkey", "root_val", "subdir_val", "key_val");
+        assertHasPrefixValues(trie, "/root/subdir/key", "root_val", "subdir_val", "key_val");
+
+        trie.remove(pathToTrieKey("/root/subdir/key"));
+        assertHasPrefixValues(trie, "/root/subdir/key/subkey", "root_val", "subdir_val");
+        assertHasPrefixValues(trie, "/root/subdir/key", "root_val", "subdir_val");
+
+        trie.remove(pathToTrieKey("/root/subdir"));
+        assertHasPrefixValues(trie, "/root/subdir/key/subkey", "root_val");
+        assertHasPrefixValues(trie, "/root/subdir/key", "root_val");
+    }
+
+    @ParameterizedTest
+    @MethodSource(value = "triesSource")
+    public void testMove(Trie<String, String> trie) {
+        putValueAndCheck(trie, "/root/dir/subdir/key1", "val1");
+        putValueAndCheck(trie, "/root/dir/subdir/key2", "val2");
+        putValueAndCheck(trie, "/root/dir/key3", "val3");
+
+        trie.move(
+            pathToTrieKey("/root/dir/subdir"),
+            pathToTrieKey("/other_dir"),
+            null
+        );
+
+        assertHasValue(trie, "/other_dir/key1", "val1");
+        assertHasValue(trie, "/other_dir/key2", "val2");
+        // check other key on the same level not affected
+        assertHasValue(trie, "/root/dir/key3", "val3");
+
+        assertNoValue(trie, "/root/dir/subdir/key1");
+        assertNoValue(trie, "/root/dir/subdir/key2");
+    }
+
+    @ParameterizedTest
+    @MethodSource(value = "triesSource")
+    public void testMoveWithinSameParent(Trie<String, String> trie) {
+        putValueAndCheck(trie, "/root/dir/subdir/key1", "val1");
+        putValueAndCheck(trie, "/root/dir/subdir/key2", "val2");
+        putValueAndCheck(trie, "/root/dir/key3", "val3");
+
+        trie.move(
+            pathToTrieKey("/root/dir/subdir"),
+            pathToTrieKey("/root/dir/other_dir"),
+            null
+        );
+
+        assertHasValue(trie, "/root/dir/other_dir/key1", "val1");
+        assertHasValue(trie, "/root/dir/other_dir/key2", "val2");
+        // check other key on the same level not affected
+        assertHasValue(trie, "/root/dir/key3", "val3");
+
+        assertNoValue(trie, "/root/dir/subdir/key1");
+        assertNoValue(trie, "/root/dir/subdir/key2");
+    }
+
+    @ParameterizedTest
+    @MethodSource(value = "triesSource")
+    public void testAcceptVisitor(Trie<String, String> trie) throws Exception {
+        Map<String, String> expectedPaths = ImmutableMap.<String, String>builder()
+            .put("/key1", "val1")
+            .put("/root/key2", "val2")
+            .put("/root/dir/key3", "val3")
+            .put("/root/dir/key4", "val4")
+            .put("/root/dir/subdir/key5", "val5")
+            .put("/root/another/key6", "val6")
+            .put("/usr/key7", "val7")
+            .build();
+
+        expectedPaths.forEach((path, val) -> putValueAndCheck(trie, path, val));
+
+        Map<String, String> actualPaths = new HashMap<>();
+        trie.accept((key, entity) -> actualPaths.put(
+            trieKeyToPath(key), entity
+        ));
+        assertEquals(expectedPaths, actualPaths);
+    }
+
+    private void putValueAndCheck(Trie<String, String> trie, String key, String value) {
+        putValue(trie, key, value);
+        assertHasValue(trie, key, value);
+    }
+
+    private void putValue(Trie<String, String> trie, String key, String value) {
+        Trie.Key<String> trieKey = pathToTrieKey(key);
+        trie.put(trieKey, value);
+    }
+
+    private void assertHasValue(Trie<String, String> trie, String key, String value) {
+        Optional<String> maybeValue = trie.get(pathToTrieKey(key));
+        assertEquals(value, maybeValue.orElse(null),
+            "Wrong value for key: " + key);
+    }
+
+    private void assertHasPrefixValues(Trie<String, String> trie, String key, String... values) {
+        List<String> maybeValue = trie.getPrefixValues(pathToTrieKey(key));
+
+        assertThat("Wrong value for key: " + key,
+            maybeValue, containsInAnyOrder(values));
+    }
+
+    private void assertNoValue(Trie<String, String> trie, String key) {
+        Optional<String> rootValue = trie.get(pathToTrieKey(key));
+        assertFalse(rootValue.isPresent());
+    }
+}

--- a/ranger-hive-chained-plugin-base/src/test/resources/mappings/fs-test-mappings.txt
+++ b/ranger-hive-chained-plugin-base/src/test/resources/mappings/fs-test-mappings.txt
@@ -1,0 +1,9 @@
+10
+{"path":"/key1","name":"table1","type":"TABLE"}
+{"path":"/usr/key7","name":"db2","type":"DATABASE"}
+{"path":"/root/key2","name":"table2","type":"TABLE"}
+{"path":"/root/another/key6","name":"table6","type":"TABLE"}
+{"path":"/root/dir","name":"db1","type":"DATABASE"}
+{"path":"/root/dir/subdir/key5","name":"table5","type":"TABLE"}
+{"path":"/root/dir/key3","name":"table3","type":"TABLE"}
+{"path":"/root/dir/key4","name":"table4","type":"TABLE"}

--- a/security-admin/src/main/java/org/apache/ranger/biz/ResourceMappingMgr.java
+++ b/security-admin/src/main/java/org/apache/ranger/biz/ResourceMappingMgr.java
@@ -22,11 +22,10 @@ package org.apache.ranger.biz;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.ranger.db.RangerDaoManager;
-import org.apache.ranger.entity.ResourceMapping;
 import org.apache.ranger.entity.XXResourceMappingDiff;
-import org.apache.ranger.view.VXResourceMapping;
-import org.apache.ranger.view.VXResourceMappingDiff;
-import org.apache.ranger.view.VXResourceMappingDiffs;
+import org.apache.ranger.plugin.model.ResourceMapping;
+import org.apache.ranger.plugin.model.ResourceMappingDiff;
+import org.apache.ranger.plugin.model.ResourceMappingDiffs;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -40,27 +39,27 @@ public class ResourceMappingMgr {
         this.rangerDaoManager = rangerDaoManager;
     }
 
-    public VXResourceMappingDiffs getDiffsNewerThan(String sourceService, String targetService, long diffId) {
+    public ResourceMappingDiffs getDiffsNewerThan(String sourceService, String targetService, long diffId) {
         List<XXResourceMappingDiff> diffs = rangerDaoManager.getXXResourceMappingDiff()
             .getDiffsNewerThan(sourceService, targetService, diffId);
         return toDto(diffs);
     }
 
-    public VXResourceMappingDiffs getAllDiffs(String sourceService, String targetService) {
+    public ResourceMappingDiffs getAllDiffs(String sourceService, String targetService) {
         List<XXResourceMappingDiff> diffs = rangerDaoManager.getXXResourceMappingDiff()
             .getAllDiffs(sourceService, targetService);
         return toDto(diffs);
     }
 
-    private VXResourceMappingDiffs toDto(List<XXResourceMappingDiff> diffs) {
-        List<VXResourceMappingDiff> diffDtos = diffs.stream()
+    private ResourceMappingDiffs toDto(List<XXResourceMappingDiff> diffs) {
+        List<ResourceMappingDiff> diffDtos = diffs.stream()
             .map(this::toDto)
             .collect(Collectors.toList());
-        return new VXResourceMappingDiffs(diffDtos);
+        return new ResourceMappingDiffs(diffDtos);
     }
 
-    private VXResourceMappingDiff toDto(XXResourceMappingDiff diff) {
-        return new VXResourceMappingDiff(
+    private ResourceMappingDiff toDto(XXResourceMappingDiff diff) {
+        return new ResourceMappingDiff(
             toDto(diff.getOldEntity()),
             toDto(diff.getNewEntity()),
             diff.getEntityType(),
@@ -71,8 +70,8 @@ public class ResourceMappingMgr {
         );
     }
 
-    private VXResourceMapping toDto(ResourceMapping mapping) {
-        return mapping == null ? null : new VXResourceMapping(
+    private ResourceMapping toDto(org.apache.ranger.entity.ResourceMapping mapping) {
+        return mapping == null ? null : new ResourceMapping(
             mapping.getName(),
             mapping.getLocation()
         );

--- a/security-admin/src/main/java/org/apache/ranger/rest/ResourceMappingsREST.java
+++ b/security-admin/src/main/java/org/apache/ranger/rest/ResourceMappingsREST.java
@@ -28,7 +28,7 @@ import javax.ws.rs.QueryParam;
 import org.apache.commons.lang.StringUtils;
 import org.apache.ranger.biz.ResourceMappingMgr;
 import org.apache.ranger.common.RESTErrorUtil;
-import org.apache.ranger.view.VXResourceMappingDiffs;
+import org.apache.ranger.plugin.model.ResourceMappingDiffs;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -53,9 +53,9 @@ public class ResourceMappingsREST {
     @GET
     @Path("/{sourceService}/{targetService}/diffs/new")
     @Produces({"application/json"})
-    public VXResourceMappingDiffs getDiffs(@PathParam("sourceService") String sourceService,
-                                           @PathParam("targetService") String targetService,
-                                           @QueryParam("fromDiffId") Long diffId) {
+    public ResourceMappingDiffs getDiffs(@PathParam("sourceService") String sourceService,
+                                         @PathParam("targetService") String targetService,
+                                         @QueryParam("fromDiffId") Long diffId) {
         if (StringUtils.isBlank(sourceService)) {
             throw restErrorUtil.createRESTException("sourceService parameter is required");
         }


### PR DESCRIPTION
- Added base chained plugin to map source service requests to Hive entity access requests, and subsequently delegate authorization to the Hive plugin
- In-memory trie-like storage was added for efficient mapping of incoming path-based entities to Hive entities (tables, databases)
- Periodical flushing of in-memory storage to the file system was implemented for faster state recovery after plugin restarts
- Added logic for periodical retrieval of resource mapping diffs from the Ranger Resource Mapping Manager
