### PR TITLE
[NGSOK-1124] Add ranger-plugin-s3-server-side in Ranger

### DIFF
--- a/agents-common/src/main/java/org/apache/ranger/plugin/store/EmbeddedServiceDefsUtil.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/store/EmbeddedServiceDefsUtil.java
@@ -47,8 +47,8 @@ public class EmbeddedServiceDefsUtil {
 	private static final Logger LOG = LoggerFactory.getLogger(EmbeddedServiceDefsUtil.class);
 
 
-	// following servicedef list should be reviewed/updated whenever a new embedded service-def is added
-	public static final String DEFAULT_BOOTSTRAP_SERVICEDEF_LIST = "tag,hdfs,hbase,hive,kms,knox,storm,yarn,kafka,solr,atlas,nifi,nifi-registry,sqoop,kylin,elasticsearch,presto,trino,ozone,kudu,schema-registry,nestedstructure";
+    // following servicedef list should be reviewed/updated whenever a new embedded service-def is added
+	public static final String DEFAULT_BOOTSTRAP_SERVICEDEF_LIST = "tag,hdfs,hbase,hive,kms,knox,storm,yarn,kafka,solr,atlas,nifi,nifi-registry,sqoop,kylin,elasticsearch,presto,trino,ozone,kudu,schema-registry,nestedstructure,s3";
 	private static final String PROPERTY_SUPPORTED_SERVICE_DEFS = "ranger.supportedcomponents";
 	private Set<String> supportedServiceDefs;
 	public static final String EMBEDDED_SERVICEDEF_TAG_NAME  = "tag";

--- a/agents-common/src/main/java/org/apache/ranger/plugin/store/EmbeddedServiceDefsUtil.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/store/EmbeddedServiceDefsUtil.java
@@ -75,6 +75,7 @@ public class EmbeddedServiceDefsUtil {
 	public static final String EMBEDDED_SERVICEDEF_OZONE_NAME  = "ozone";
 	public static final String EMBEDDED_SERVICEDEF_KUDU_NAME  = "kudu";
 	public static final String EMBEDDED_SERVICEDEF_NESTEDSTRUCTURE_NAME  = "nestedstructure";
+    public static final String EMBEDDED_SERVICEDEF_S3_NAME = "s3";
 
 	public static final String PROPERTY_CREATE_EMBEDDED_SERVICE_DEFS = "ranger.service.store.create.embedded.service-defs";
 
@@ -94,6 +95,7 @@ public class EmbeddedServiceDefsUtil {
 	public static final String TRINO_IMPL_CLASS_NAME  = "org.apache.ranger.services.trino.RangerServiceTrino";
 	public static final String OZONE_IMPL_CLASS_NAME  = "org.apache.ranger.services.ozone.RangerServiceOzone";
 	public static final String KUDU_IMPL_CLASS_NAME  = "org.apache.ranger.services.kudu.RangerServiceKudu";
+    public static final String S3_IMPL_CLASS_NAME  = "org.apache.ranger.services.s3.RangerServiceS3";
 
 	private static EmbeddedServiceDefsUtil instance = new EmbeddedServiceDefsUtil();
 
@@ -121,6 +123,7 @@ public class EmbeddedServiceDefsUtil {
 	private RangerServiceDef ozoneServiceDef;
 	private RangerServiceDef kuduServiceDef;
 	private RangerServiceDef nestedStructureServiveDef;
+	private RangerServiceDef s3ServiceDef;
 
 	private RangerServiceDef tagServiceDef;
 
@@ -171,6 +174,7 @@ public class EmbeddedServiceDefsUtil {
 			ozoneServiceDef = getOrCreateServiceDef(store, EMBEDDED_SERVICEDEF_OZONE_NAME);
 			kuduServiceDef = getOrCreateServiceDef(store, EMBEDDED_SERVICEDEF_KUDU_NAME);
 			nestedStructureServiveDef = getOrCreateServiceDef(store, EMBEDDED_SERVICEDEF_NESTEDSTRUCTURE_NAME);
+			s3ServiceDef = getOrCreateServiceDef(store, EMBEDDED_SERVICEDEF_S3_NAME);
 
 			// Ensure that tag service def is updated with access types of all service defs
 			store.updateTagServiceDefForAccessTypes();
@@ -259,6 +263,8 @@ public class EmbeddedServiceDefsUtil {
 	public long getKuduServiceDefId() { return getId(kuduServiceDef); }
 
 	public long getNestedStructureServiceDefId() { return getId(nestedStructureServiveDef); }
+
+    public long getS3ServiceDefId() { return getId(s3ServiceDef); }
 
 	public RangerServiceDef getEmbeddedServiceDef(String defType) throws Exception {
 		RangerServiceDef serviceDef=null;

--- a/agents-common/src/main/resources/service-defs/ranger-servicedef-s3.json
+++ b/agents-common/src/main/resources/service-defs/ranger-servicedef-s3.json
@@ -1,0 +1,126 @@
+{
+    "id": 202,
+    "name": "s3",
+    "displayName": "s3",
+    "implClass": "org.apache.ranger.services.s3.RangerServiceS3",
+    "label": "S3",
+    "description": "S3 Repository",
+    "guid": "b8290b7f-6f69-44a9-89cc-06b6975ea676",
+    "resources": [
+        {
+            "itemId": 1,
+            "name": "endpoint",
+            "type": "string",
+            "level": 10,
+            "mandatory": true,
+            "lookupSupported": true,
+            "recursiveSupported": false,
+            "excludesSupported": true,
+            "matcher": "org.apache.ranger.plugin.resourcematcher.RangerDefaultResourceMatcher",
+            "matcherOptions": {
+                "wildCard": "true",
+                "ignoreCase": "false"
+            },
+            "label": "S3 Endpoint",
+            "description": "S3 Endpoint",
+            "isValidLeaf": false
+        },
+        {
+            "itemId": 2,
+            "name": "bucket",
+            "type": "string",
+            "level": 20,
+            "parent": "endpoint",
+            "mandatory": true,
+            "lookupSupported": true,
+            "recursiveSupported": false,
+            "excludesSupported": true,
+            "matcher": "org.apache.ranger.plugin.resourcematcher.RangerDefaultResourceMatcher",
+            "matcherOptions": {
+                "wildCard": "true",
+                "ignoreCase": "false"
+            },
+            "label": "S3 Bucket",
+            "description": "S3 Bucket",
+            "isValidLeaf": true
+        },
+        {
+            "itemId": 3,
+            "name": "path",
+            "type": "string",
+            "level": 30,
+            "parent": "bucket",
+            "mandatory": true,
+            "lookupSupported": true,
+            "recursiveSupported": false,
+            "excludesSupported": true,
+            "matcher": "org.apache.ranger.plugin.resourcematcher.RangerDefaultResourceMatcher",
+            "matcherOptions": {
+                "wildCard": "true",
+                "ignoreCase": "false"
+            },
+            "label": "S3 Path",
+            "description": "S3 Path",
+            "isValidLeaf": true
+        }
+    ],
+    "accessTypes": [
+        {
+            "itemId": 1,
+            "name": "read",
+            "label": "Read"
+        },
+        {
+            "itemId": 2,
+            "name": "write",
+            "label": "Write"
+        }
+    ],
+    "configs": [
+        {
+            "itemId": 1,
+            "name": "endpoint",
+            "type": "string",
+            "mandatory": true,
+            "label": "S3 Endpoint",
+            "description": "S3 Endpoint URL (e.g., s3://host:port)"
+        },
+        {
+            "itemId": 2,
+            "name": "accesskey",
+            "type": "string",
+            "mandatory": true,
+            "label": "Access Key",
+            "description": "AWS Access Key"
+        },
+        {
+            "itemId": 3,
+            "name": "password",
+            "type": "password",
+            "mandatory": true,
+            "label": "Secret Key",
+            "description": "AWS Secret Key"
+        },
+        {
+            "itemId": 4,
+            "name": "region",
+            "type": "string",
+            "mandatory": false,
+            "defaultValue": "eu-west-1",
+            "label": "AWS Region",
+            "description": "AWS Region (default: eu-west-1)"
+        }
+    ],
+    "policyConditions": [
+        {
+            "itemId": 1,
+            "name": "ip-range",
+            "evaluator": "org.apache.ranger.plugin.conditionevaluator.RangerIpMatcher",
+            "label": "IP Address Range",
+            "description": "IP Address Range"
+        }
+    ],
+    "dataMaskDef": {},
+    "rowFilterDef": {}
+}
+

--- a/dev-support/ranger-docker/scripts/create-ranger-services.py
+++ b/dev-support/ranger-docker/scripts/create-ranger-services.py
@@ -65,7 +65,15 @@ ozone = RangerService({'name': 'dev_ozone',
                                    'ozone.om.http-address': 'http://om:9874',
                                    'hadoop.security.authentication': 'simple'}})
 
-services = [hdfs, yarn, hive, hbase, kafka, knox, kms, trino, ozone]
+s3 = RangerService({'name': 'dev_s3',
+                    'type': 's3',
+                    'displayName': 'dev_s3',
+                    'configs': {'endpoint': 's3://localhost:9000',
+                                'accesskey': 'minioadmin',
+                                'password': 'minioadmin',
+                                'region': 'us-east-1'}})
+
+services = [hdfs, yarn, hive, hbase, kafka, knox, kms, trino, ozone, s3]
 for service in services:
     try:
         if service_not_exists(service):

--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -1004,6 +1004,35 @@
             </build>
         </profile>
         <profile>
+            <id>ranger-s3-plugin</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-assembly-plugin</artifactId>
+                        <version>${assembly.plugin.version}</version>
+                        <configuration>
+                            <finalName>ranger-${project.version}</finalName>
+                            <outputDirectory>../target</outputDirectory>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>single</goal>
+                                </goals>
+                                <phase>package</phase>
+                                <configuration>
+                                    <skipAssembly>false</skipAssembly>
+                                    <descriptors>
+                                        <descriptor>src/main/assembly/plugin-s3.xml</descriptor>
+                                    </descriptors>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
             <id>ranger-schema-registry-plugin</id>
             <build>
                 <plugins>

--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -308,13 +308,13 @@
         </dependency>
         <dependency>
             <groupId>io.arenadata.ranger</groupId>
-            <artifactId>ranger-schema-registry-plugin</artifactId>
+            <artifactId>ranger-s3-plugin</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.arenadata.ranger</groupId>
-            <artifactId>ranger-s3-plugin</artifactId>
+            <artifactId>ranger-schema-registry-plugin</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>

--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -314,6 +314,12 @@
         </dependency>
         <dependency>
             <groupId>io.arenadata.ranger</groupId>
+            <artifactId>ranger-s3-plugin</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.arenadata.ranger</groupId>
             <artifactId>ranger-solr-plugin</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>

--- a/distro/src/main/assembly/plugin-s3.xml
+++ b/distro/src/main/assembly/plugin-s3.xml
@@ -26,8 +26,8 @@
         <moduleSet>
             <useAllReactorProjects>true</useAllReactorProjects>
             <includes>
-                <include>org.apache.ranger:ranger-plugins-installer</include>
-                <include>org.apache.ranger:credentialbuilder</include>
+                <include>io.arenadata.ranger:ranger-plugins-installer</include>
+                <include>io.arenadata.ranger:credentialbuilder</include>
             </includes>
             <binaries>
                 <outputDirectory>install/lib</outputDirectory>
@@ -62,10 +62,10 @@
         <moduleSet>
             <useAllReactorProjects>true</useAllReactorProjects>
             <includes>
-                <include>org.apache.ranger:ranger-plugins-audit</include>
-                <include>org.apache.ranger:ranger-plugins-cred</include>
-                <include>org.apache.ranger:ranger-plugins-common</include>
-                <include>org.apache.ranger:ranger-s3-plugin</include>
+                <include>io.arenadata.ranger:ranger-plugins-audit</include>
+                <include>io.arenadata.ranger:ranger-plugins-cred</include>
+                <include>io.arenadata.ranger:ranger-plugins-common</include>
+                <include>io.arenadata.ranger:ranger-s3-plugin</include>
             </includes>
             <binaries>
                 <outputDirectory>lib</outputDirectory>

--- a/distro/src/main/assembly/plugin-s3.xml
+++ b/distro/src/main/assembly/plugin-s3.xml
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<assembly>
+    <id>s3-plugin</id>
+    <formats>
+        <format>tar.gz</format>
+    </formats>
+    <baseDirectory>${project.parent.name}-${project.version}-s3-plugin</baseDirectory>
+    <includeBaseDirectory>true</includeBaseDirectory>
+    <moduleSets>
+        <moduleSet>
+            <useAllReactorProjects>true</useAllReactorProjects>
+            <includes>
+                <include>org.apache.ranger:ranger-plugins-installer</include>
+                <include>org.apache.ranger:credentialbuilder</include>
+            </includes>
+            <binaries>
+                <outputDirectory>install/lib</outputDirectory>
+                <includeDependencies>true</includeDependencies>
+                <unpack>false</unpack>
+                <includes>
+                    <include>com.fasterxml.woodstox:woodstox-core:jar:${fasterxml.woodstox.version}</include>
+                    <include>com.kstruct:gethostname4j</include>
+                    <include>com.sun.jersey:jersey-bundle</include>
+                    <include>com.sun.jersey:jersey-core</include>
+                    <include>com.sun.jersey:jersey-client</include>
+                    <include>commons-cli:commons-cli</include>
+                    <include>commons-collections:commons-collections</include>
+                    <include>commons-configuration:commons-configuration:jar:${commons.configuration1.version}</include>
+                    <include>commons-io:commons-io:jar:${commons.io.version}</include>
+                    <include>commons-lang:commons-lang</include>
+                    <include>commons-logging:commons-logging:jar:${commons.logging.version}</include>
+                    <include>net.java.dev.jna:jna</include>
+                    <include>net.java.dev.jna:jna-platform</include>
+                    <include>org.apache.commons:commons-compress:jar:${commons.compress.version}</include>
+                    <include>org.apache.commons:commons-configuration2:jar:${commons.configuration.version}</include>
+                    <include>org.apache.commons:commons-lang3:jar:${commons.lang3.version}</include>
+                    <include>org.apache.hadoop:hadoop-auth:jar:${hadoop.version}</include>
+                    <include>org.apache.hadoop:hadoop-common:jar:${hadoop.version}</include>
+                    <include>org.apache.hadoop.thirdparty:hadoop-shaded-guava:jar:${hadoop-shaded-guava.version}</include>
+                    <include>org.codehaus.woodstox:stax2-api:jar:${codehaus.woodstox.stax2api.version}</include>
+                    <include>org.slf4j:slf4j-api:jar:${slf4j-api.version}</include>
+                </includes>
+            </binaries>
+        </moduleSet>
+
+        <moduleSet>
+            <useAllReactorProjects>true</useAllReactorProjects>
+            <includes>
+                <include>org.apache.ranger:ranger-plugins-audit</include>
+                <include>org.apache.ranger:ranger-plugins-cred</include>
+                <include>org.apache.ranger:ranger-plugins-common</include>
+                <include>org.apache.ranger:ranger-s3-plugin</include>
+            </includes>
+            <binaries>
+                <outputDirectory>lib</outputDirectory>
+                <includeDependencies>true</includeDependencies>
+                <unpack>false</unpack>
+                <directoryMode>755</directoryMode>
+                <fileMode>644</fileMode>
+                <includes>
+                    <include>org.apache.commons:commons-configuration2:jar:${commons.configuration.version}</include>
+                    <include>commons-configuration:commons-configuration:jar:${commons.configuration1.version}</include>
+                    <include>org.apache.httpcomponents:httpmime:jar:${httpcomponents.httpmime.version}</include>
+                    <include>org.apache.httpcomponents:httpclient:jar:${httpcomponents.httpclient.version}</include>
+                    <include>org.apache.httpcomponents:httpcore:jar:${httpcomponents.httpcore.version}</include>
+                    <include>com.sun.jersey:jersey-core</include>
+                    <include>com.sun.jersey:jersey-client</include>
+                    <include>com.sun.jersey:jersey-bundle</include>
+                    <include>com.fasterxml.jackson.core:jackson-annotations:jar:${fasterxml.jackson.version}</include>
+                    <include>com.fasterxml.jackson.core:jackson-core:jar:${fasterxml.jackson.version}</include>
+                    <include>com.fasterxml.jackson.core:jackson-databind:jar:${fasterxml.jackson.version}</include>
+                    <include>com.amazonaws:aws-java-sdk-s3</include>
+                    <include>com.amazonaws:aws-java-sdk-core</include>
+                    <include>com.amazonaws:aws-java-sdk-kms</include>
+                    <include>com.amazonaws:jmespath-java</include>
+                    <include>commons-lang:commons-lang</include>
+                    <include>com.kstruct:gethostname4j</include>
+                    <include>net.java.dev.jna:jna</include>
+                    <include>net.java.dev.jna:jna-platform</include>
+                </includes>
+            </binaries>
+        </moduleSet>
+    </moduleSets>
+
+    <fileSets>
+        <fileSet>
+            <outputDirectory>install/conf.templates/enable</outputDirectory>
+            <directory>../plugin-s3/conf</directory>
+            <excludes>
+                <exclude>*.sh</exclude>
+            </excludes>
+            <fileMode>700</fileMode>
+        </fileSet>
+        <fileSet>
+            <outputDirectory></outputDirectory>
+            <directory>${project.build.outputDirectory}</directory>
+            <includes>
+                <include>version</include>
+            </includes>
+            <fileMode>444</fileMode>
+        </fileSet>
+    </fileSets>
+    <files>
+        <file>
+            <source>${project.parent.basedir}/agents-common/scripts/enable-agent.sh</source>
+            <outputDirectory></outputDirectory>
+            <destName>enable-s3-plugin.sh</destName>
+            <fileMode>755</fileMode>
+        </file>
+        <file>
+            <source>${project.parent.basedir}/agents-common/scripts/enable-agent.sh</source>
+            <outputDirectory></outputDirectory>
+            <destName>disable-s3-plugin.sh</destName>
+            <fileMode>755</fileMode>
+        </file>
+        <file>
+            <source>${project.parent.basedir}/security-admin/scripts/ranger_credential_helper.py</source>
+            <outputDirectory></outputDirectory>
+            <fileMode>755</fileMode>
+        </file>
+    </files>
+</assembly>

--- a/plugin-s3/conf/ranger-policymgr-ssl.xml
+++ b/plugin-s3/conf/ranger-policymgr-ssl.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<configuration>
+</configuration>

--- a/plugin-s3/conf/ranger-s3-audit.xml
+++ b/plugin-s3/conf/ranger-s3-audit.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<configuration>
+</configuration>

--- a/plugin-s3/conf/ranger-s3-security.xml
+++ b/plugin-s3/conf/ranger-s3-security.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<configuration>
+    <property>
+        <name>ranger.plugin.s3.policy.rest.url</name>
+        <value></value>
+        <description>
+            URL to Ranger Admin
+        </description>
+    </property>
+
+    <property>
+        <name>ranger.plugin.s3.service.name</name>
+        <value></value>
+        <description>
+            Name of the Ranger service containing policies for this S3 instance
+        </description>
+    </property>
+
+    <property>
+        <name>ranger.plugin.s3.policy.cache.dir</name>
+        <value></value>
+        <description>
+            Directory where Ranger policies are cached after successful retrieval from the source
+        </description>
+    </property>
+</configuration>

--- a/plugin-s3/pom.xml
+++ b/plugin-s3/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.ranger</groupId>
+        <artifactId>ranger</artifactId>
+        <version>2.6.0</version>
+        <relativePath>..</relativePath>
+    </parent>
+    <artifactId>ranger-s3-plugin</artifactId>
+    <packaging>jar</packaging>
+    <name>S3 Security Plugin</name>
+    <description>S3 Security Plugin</description>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-s3</artifactId>
+            <version>${aws-java-sdk.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>${fasterxml.jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${fasterxml.jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${fasterxml.jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+            <version>${commons.logging.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.ranger</groupId>
+            <artifactId>credentialbuilder</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.ranger</groupId>
+            <artifactId>ranger-plugins-audit</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.ranger</groupId>
+            <artifactId>ranger-plugins-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/plugin-s3/pom.xml
+++ b/plugin-s3/pom.xml
@@ -18,7 +18,7 @@ limitations under the License.
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.apache.ranger</groupId>
+        <groupId>io.arenadata.ranger</groupId>
         <artifactId>ranger</artifactId>
         <version>2.6.0</version>
         <relativePath>..</relativePath>
@@ -63,17 +63,17 @@ limitations under the License.
             <version>${commons.logging.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.ranger</groupId>
+            <groupId>io.arenadata.ranger</groupId>
             <artifactId>credentialbuilder</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.ranger</groupId>
+            <groupId>io.arenadata.ranger</groupId>
             <artifactId>ranger-plugins-audit</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.ranger</groupId>
+            <groupId>io.arenadata.ranger</groupId>
             <artifactId>ranger-plugins-common</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/plugin-s3/src/main/java/org/apache/ranger/services/s3/RangerServiceS3.java
+++ b/plugin-s3/src/main/java/org/apache/ranger/services/s3/RangerServiceS3.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.services.s3;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.ranger.plugin.service.RangerBaseService;
+import org.apache.ranger.plugin.service.ResourceLookupContext;
+import org.apache.ranger.services.s3.client.S3ResourceManager;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * RangerServiceS3 provides integration between Apache Ranger and Amazon S3 compatible storage services.
+ * This service implementation enables policy-based access control for S3 buckets and objects.
+ * 
+ * <p>The service supports:
+ * <ul>
+ *   <li>Connection validation to S3 endpoints</li>
+ *   <li>Resource lookup for buckets and paths</li>
+ *   <li>Integration with Ranger policy engine</li>
+ * </ul>
+ */
+public class RangerServiceS3 extends RangerBaseService {
+
+    private static final Log LOG = LogFactory.getLog(RangerServiceS3.class);
+
+    /**
+     * Validates the configuration for connecting to an S3 service.
+     * 
+     * @return Map containing validation results with status and error messages if any
+     * @throws Exception if validation fails due to connection or configuration errors
+     */
+    @Override
+    public Map<String, Object> validateConfig() throws Exception {
+        Map<String, Object> ret = new HashMap<String, Object>();
+        String serviceName = getServiceName();
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("RangerServiceS3.validateConfig(): Service: " + serviceName);
+        }
+
+        if (configs != null) {
+            try {
+                ret = S3ResourceManager.validateConfig(configs);
+            } catch (Exception e) {
+                LOG.error("Error validating S3 config for service: " + serviceName, e);
+                throw e;
+            }
+        }
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("RangerServiceS3.validateConfig(): Response: " + ret);
+        }
+        return ret;
+    }
+
+    /**
+     * Looks up S3 resources (buckets and paths) based on the provided context.
+     * This method is used by the Ranger Admin UI to provide auto-complete functionality
+     * when creating policies.
+     * 
+     * @param context ResourceLookupContext containing user input and resource hierarchy information
+     * @return List of matching resource names (bucket names or paths)
+     * @throws Exception if resource lookup fails due to connection or permission errors
+     */
+    @Override
+    public List<String> lookupResource(ResourceLookupContext context) throws Exception {
+        List<String> ret = new ArrayList<String>();
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("RangerServiceS3.lookupResource() Context: " + context);
+        }
+
+        if (context != null) {
+            try {
+                ret = S3ResourceManager.getResources(configs, context);
+            } catch (Exception e) {
+                LOG.error("Error looking up S3 resources", e);
+                throw e;
+            }
+        }
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("RangerServiceS3.lookupResource() Response: " + ret);
+        }
+        return ret;
+    }
+}

--- a/plugin-s3/src/main/java/org/apache/ranger/services/s3/client/S3Client.java
+++ b/plugin-s3/src/main/java/org/apache/ranger/services/s3/client/S3Client.java
@@ -1,0 +1,275 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.services.s3.client;
+
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.Bucket;
+import com.amazonaws.services.s3.model.ObjectListing;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.ranger.plugin.util.PasswordUtils;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * S3Client provides connectivity to Amazon S3 compatible storage services
+ * and implements resource discovery operations for Apache Ranger integration.
+ * 
+ * <p>This client supports:
+ * <ul>
+ *   <li>Connection testing and validation</li>
+ *   <li>Bucket listing and filtering</li>
+ *   <li>Path-based resource lookup with auto-complete</li>
+ *   <li>Custom S3-compatible endpoints (e.g., MinIO, Ceph)</li>
+ * </ul>
+ * 
+ * <p>The client uses path-style access for compatibility with S3-compatible services.
+ */
+public class S3Client {
+    private static final Log LOG = LogFactory.getLog(S3Client.class);
+    private static final String DEFAULT_AWS_REGION = "us-east-1";
+    private static final int MAX_RESOURCE_RESULTS = 50;
+
+    private String endpoint;
+    private String accessKey;
+    private String secretKey;
+    private String awsRegion;
+
+    /**
+     * Constructs an S3Client with the provided configuration.
+     * 
+     * @param configs Map containing connection parameters:
+     *                - endpoint: S3 service URL (e.g., s3://localhost:9000)
+     *                - accesskey: AWS access key or compatible credential
+     *                - password: Encrypted secret key (will be decrypted)
+     *                - region: AWS region (optional, defaults to us-east-1)
+     * @throws Exception if required configuration is missing or invalid
+     */
+    public S3Client(Map<String, String> configs) throws Exception {
+        this.endpoint = configs.get("endpoint");
+        this.accessKey = configs.get("accesskey");
+        this.secretKey = PasswordUtils.decryptPassword(configs.get("password"));
+        this.awsRegion = configs.getOrDefault("region", DEFAULT_AWS_REGION);
+
+        validateConfiguration();
+    }
+
+    /**
+     * Validates the S3 client configuration.
+     * 
+     * @throws Exception if configuration is invalid
+     */
+    private void validateConfiguration() throws Exception {
+        if (this.endpoint == null || this.endpoint.isEmpty()) {
+            logError("Configuration 'endpoint' is required. Please provide URL in format s3://host:port");
+        }
+        if (this.accessKey == null || this.accessKey.isEmpty()) {
+            logError("Configuration 'accesskey' is required");
+        }
+        if (this.secretKey == null || this.secretKey.isEmpty()) {
+            logError("Configuration 'password' (secret key) is required");
+        }
+    }
+
+    /**
+     * Logs an error message and throws an exception.
+     * 
+     * @param errorMessage Error message to log and throw
+     * @throws Exception always throws with the provided message
+     */
+    private static void logError(String errorMessage) throws Exception {
+        LOG.error(errorMessage);
+        throw new Exception(errorMessage);
+    }
+
+    /**
+     * Creates and configures an Amazon S3 client instance.
+     * 
+     * <p>The client is configured with:
+     * <ul>
+     *   <li>Static AWS credentials</li>
+     *   <li>S3SignerType for compatibility with older S3 implementations</li>
+     *   <li>Path-style access for custom endpoints</li>
+     * </ul>
+     * 
+     * @return Configured AmazonS3 client instance
+     */
+    private AmazonS3 getAWSClient() {
+        AWSCredentials credentials = new BasicAWSCredentials(this.accessKey, this.secretKey);
+        
+        // S3SignerType is required until HTTP client libraries allow raw User-Agent headers.
+        // Some proxies (e.g., Airlock) modify User-Agent causing signature mismatch.
+        ClientConfiguration conf = new ClientConfiguration();
+        conf.setSignerOverride("S3SignerType");
+
+        AmazonS3ClientBuilder client = AmazonS3ClientBuilder
+                .standard()
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .withClientConfiguration(conf)
+                .withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(endpoint, awsRegion));
+
+        client.setPathStyleAccessEnabled(true);
+        return client.build();
+    }
+
+    /**
+     * Tests connectivity to the S3 service by attempting to list buckets.
+     * 
+     * @return Map containing connection test results with fields:
+     *         - connectivityStatus: true/false
+     *         - message: Success or error message
+     */
+    public Map<String, Object> connectionTest() {
+        Map<String, Object> responseData = new HashMap<String, Object>();
+
+        try {
+            List<Bucket> buckets = getAWSClient().listBuckets();
+
+            if (buckets == null || buckets.isEmpty()) {
+                responseData.put("connectivityStatus", false);
+                responseData.put("message", "Connection successful but no buckets found. Verify permissions.");
+                LOG.warn("S3 connection test: no buckets returned");
+            } else {
+                responseData.put("connectivityStatus", true);
+                responseData.put("message", "Connection test successful. Found " + buckets.size() + " bucket(s).");
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("S3 connection test successful. Buckets: " + buckets.size());
+                }
+            }
+        } catch (Exception e) {
+            responseData.put("connectivityStatus", false);
+            responseData.put("message", "Connection failed: " + e.getMessage());
+            LOG.error("S3 connection test failed", e);
+        }
+        return responseData;
+    }
+
+    /**
+     * Removes leading slash from user input if present.
+     * 
+     * @param userInput Input string that may start with '/'
+     * @return String without leading slash
+     */
+    private String removeLeadingSlash(final String userInput) {
+        if (userInput != null && userInput.startsWith("/")) {
+            return userInput.substring(1);
+        }
+        return userInput;
+    }
+
+    /**
+     * Retrieves S3 resource paths (buckets and pseudo-directories) matching the user input.
+     * 
+     * <p>This method implements intelligent auto-complete functionality:
+     * <ul>
+     *   <li>Returns matching bucket names if input is a bucket prefix</li>
+     *   <li>Returns pseudo-directories within a bucket if input includes path</li>
+     *   <li>Results are sorted and limited to {@link #MAX_RESOURCE_RESULTS}</li>
+     * </ul>
+     * 
+     * @param userInput User-provided search string (e.g., "/my-bucket" or "/my-bucket/folder/")
+     * @return List of matching resource paths, each starting with '/'
+     */
+    public List<String> getResourcePaths(final String userInput) {
+        Supplier<Stream<Bucket>> buckets = () -> getAWSClient().listBuckets().stream();
+        String[] userInputSplit = removeLeadingSlash(userInput).split("/");
+        String bucketFilter = userInputSplit[0];
+        String subdirFilter;
+
+        if (userInputSplit.length >= 2) {
+            subdirFilter = userInput.substring(removeLeadingSlash(userInput).indexOf("/") + 2);
+        } else {
+            subdirFilter = "";
+        }
+
+        List<String> bucketsPaths = buckets
+                .get()
+                .filter(b -> b.getName().startsWith(bucketFilter))
+                .flatMap(b -> {
+                    if (subdirFilter.length() > 0 || userInput.endsWith("/")) {
+                        return getBucketPseudoDirectories(b.getName(), subdirFilter).stream();
+                    } else {
+                        return buckets.get()
+                                .filter(sb -> sb.getName().startsWith(bucketFilter))
+                                .map(sb -> String.format("/%s", sb.getName()));
+                    }
+                })
+                .distinct()
+                .sorted()
+                .limit(MAX_RESOURCE_RESULTS)
+                .collect(Collectors.toList());
+
+        return bucketsPaths;
+    }
+
+    /**
+     * Retrieves pseudo-directories within an S3 bucket.
+     * 
+     * <p>S3 does not have true directories, but this method infers directory structure
+     * from object keys containing '/' characters. Objects with size 0 are treated as
+     * directory markers.
+     * 
+     * @param bucket Bucket name to search within
+     * @param subdirFilter Optional prefix filter for subdirectories
+     * @return List of pseudo-directory paths in format "/bucket/path/"
+     */
+    public List<String> getBucketPseudoDirectories(final String bucket, final String subdirFilter) {
+        ObjectListing bucketObjects = getAWSClient().listObjects(bucket);
+
+        List<String> pseudoDirsFiltered = bucketObjects
+                .getObjectSummaries()
+                .stream()
+                .filter(p -> {
+                    if (subdirFilter != null && subdirFilter.length() > 0) {
+                        return p.getKey().startsWith(subdirFilter);
+                    } else {
+                        return true;
+                    }
+                })
+                .map(p -> {
+                    // Objects with size 0 are typically directory markers
+                    if (p.getSize() == 0) {
+                        return String.format("/%s/%s", bucket, p.getKey());
+                    } else {
+                        // Extract directory path from object key
+                        int endIndex = p.getKey().contains("/") ? p.getKey().lastIndexOf("/") : 0;
+                        if (endIndex > 0) {
+                            return String.format("/%s/%s/", bucket, p.getKey().substring(0, endIndex));
+                        } else {
+                            return String.format("/%s/", bucket);
+                        }
+                    }
+                })
+                .collect(Collectors.toList());
+
+        return pseudoDirsFiltered;
+    }
+}

--- a/plugin-s3/src/main/java/org/apache/ranger/services/s3/client/S3ResourceManager.java
+++ b/plugin-s3/src/main/java/org/apache/ranger/services/s3/client/S3ResourceManager.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.services.s3.client;
+
+import org.apache.ranger.plugin.service.ResourceLookupContext;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * S3ResourceManager provides static utility methods for managing S3 client instances
+ * and performing resource operations such as configuration validation and resource lookup.
+ * 
+ * <p>This class acts as a facade for S3Client operations, ensuring proper error handling
+ * and resource management.
+ */
+public class S3ResourceManager {
+
+    /**
+     * Creates and returns an S3Client instance configured with the provided settings.
+     * 
+     * @param configs Map containing S3 connection configuration (endpoint, accesskey, password, region)
+     * @return Configured S3Client instance, or null if configs is null
+     * @throws Exception if client creation fails due to invalid configuration
+     */
+    public static S3Client getS3Client(Map<String, String> configs) throws Exception {
+        if (configs != null) {
+            return new S3Client(configs);
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Validates the S3 service configuration by attempting to establish a connection
+     * and perform a basic operation (list buckets).
+     * 
+     * @param configs Map containing S3 connection configuration
+     * @return Map containing validation results with 'connectivityStatus' and 'message' fields
+     * @throws Exception if validation fails due to connection or authentication errors
+     */
+    public static Map<String, Object> validateConfig(Map<String, String> configs) throws Exception {
+        Map<String, Object> ret = new HashMap<>();
+        S3Client client = getS3Client(configs);
+
+        if (client != null) {
+            ret = client.connectionTest();
+        }
+        return ret;
+    }
+
+    /**
+     * Retrieves a list of S3 resources (buckets and paths) matching the user input from the context.
+     * This method is used to provide auto-complete functionality in the Ranger Admin UI.
+     * 
+     * @param configs Map containing S3 connection configuration
+     * @param context ResourceLookupContext containing user input and resource hierarchy
+     * @return List of matching resource paths, or null if no matches found
+     * @throws Exception if resource lookup fails due to connection or permission errors
+     */
+    public static List<String> getResources(Map<String, String> configs, ResourceLookupContext context) throws Exception {
+        String userInput = context.getUserInput();
+        List<String> resources = null;
+        final S3Client client = getS3Client(configs);
+
+        if (client != null) {
+            resources = client.getResourcePaths(userInput);
+        }
+        return resources;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -832,6 +832,7 @@
                 <module>plugin-nifi-registry</module>
                 <module>plugin-ozone</module>
                 <module>plugin-presto</module>
+                <module>plugin-s3</module>
                 <module>plugin-schema-registry</module>
                 <module>plugin-solr</module>
                 <module>plugin-sqoop</module>
@@ -989,6 +990,7 @@
                 <module>agents-installer</module>
                 <module>credentialbuilder</module>
                 <module>plugin-ozone</module>
+                <module>plugin-s3</module>
                 <module>ranger-hive-chained-plugin-base</module>
                 <module>ranger-hive-chained-plugin-hdfs</module>
                 <module>ranger-hive-chained-plugin-ozone</module>
@@ -1174,6 +1176,7 @@
                 <module>plugin-nifi-registry</module>
                 <module>plugin-ozone</module>
                 <module>plugin-presto</module>
+                <module>plugin-s3</module>
                 <module>plugin-schema-registry</module>
                 <module>plugin-solr</module>
                 <module>plugin-sqoop</module>
@@ -1262,6 +1265,7 @@
                 <module>plugin-nifi-registry</module>
                 <module>plugin-ozone</module>
                 <module>plugin-presto</module>
+                <module>plugin-s3</module>
                 <module>plugin-schema-registry</module>
                 <module>plugin-solr</module>
                 <module>plugin-sqoop</module>


### PR DESCRIPTION
Added ranger-s3 plugin for S3 storage access control via Apache Ranger.
ranger-s3 is an Apache Ranger integration plugin for Amazon S3 and S3-compatible storage systems.
Provides centralized security policy management for S3 resources:
- S3 endpoint connection validation
- Hierarchical access control (endpoint → bucket → path)
- Read and write operations