### PR TITLE
ADH-8085 Implement xasecure.policymgr.clientssl.*.password

### DIFF
--- a/agents-audit/src/main/java/org/apache/ranger/audit/destination/SolrAuditDestination.java
+++ b/agents-audit/src/main/java/org/apache/ranger/audit/destination/SolrAuditDestination.java
@@ -384,7 +384,12 @@ public class SolrAuditDestination extends AuditDestination {
 		String credentialProviderPath = MiscUtil.getStringProperty(props, RANGER_POLICYMGR_CLIENT_KEY_FILE_CREDENTIAL);
 		String keyStoreAlias = RANGER_POLICYMGR_CLIENT_KEY_FILE_CREDENTIAL_ALIAS;
 		String keyStoreFile = MiscUtil.getStringProperty(props, RANGER_POLICYMGR_CLIENT_KEY_FILE);
-		String keyStoreFilepwd = MiscUtil.getCredentialString(credentialProviderPath, keyStoreAlias);
+		String keyStoreFilepwd = MiscUtil.getStringProperty(props, RANGER_POLICYMGR_CLIENT_KEY_FILE_PASSWORD);
+
+		if (StringUtils.isNotEmpty(credentialProviderPath) && StringUtils.isNotEmpty(keyStoreAlias)) {
+			keyStoreFilepwd = MiscUtil.getCredentialString(credentialProviderPath, keyStoreAlias);
+		}
+
 		if (StringUtils.isNotEmpty(keyStoreFile) && StringUtils.isNotEmpty(keyStoreFilepwd)) {
 			InputStream in = null;
 
@@ -431,7 +436,12 @@ public class SolrAuditDestination extends AuditDestination {
 		String credentialProviderPath = MiscUtil.getStringProperty(props, RANGER_POLICYMGR_TRUSTSTORE_FILE_CREDENTIAL);
 		String trustStoreAlias = RANGER_POLICYMGR_TRUSTSTORE_FILE_CREDENTIAL_ALIAS;
 		String trustStoreFile = MiscUtil.getStringProperty(props, RANGER_POLICYMGR_TRUSTSTORE_FILE);
-		String trustStoreFilepwd = MiscUtil.getCredentialString(credentialProviderPath, trustStoreAlias);
+		String trustStoreFilepwd = MiscUtil.getStringProperty(props, RANGER_POLICYMGR_TRUSTSTORE_FILE_PASSWORD);
+
+		if (StringUtils.isNotEmpty(credentialProviderPath) && StringUtils.isNotEmpty(trustStoreAlias)) {
+			trustStoreFilepwd = MiscUtil.getCredentialString(credentialProviderPath, trustStoreAlias);
+		}
+
 		if (StringUtils.isNotEmpty(trustStoreFile) && StringUtils.isNotEmpty(trustStoreFilepwd)) {
 			InputStream in = null;
 

--- a/agents-audit/src/main/java/org/apache/ranger/audit/provider/BaseAuditHandler.java
+++ b/agents-audit/src/main/java/org/apache/ranger/audit/provider/BaseAuditHandler.java
@@ -44,12 +44,14 @@ public abstract class BaseAuditHandler implements AuditHandler {
 	public static final String RANGER_POLICYMGR_CLIENT_KEY_FILE_TYPE             = "xasecure.policymgr.clientssl.keystore.type";
 	public static final String RANGER_POLICYMGR_CLIENT_KEY_FILE_CREDENTIAL       = "xasecure.policymgr.clientssl.keystore.credential.file";
 	public static final String RANGER_POLICYMGR_CLIENT_KEY_FILE_CREDENTIAL_ALIAS = "sslKeyStore";
+	public static final String RANGER_POLICYMGR_CLIENT_KEY_FILE_PASSWORD         = "xasecure.policymgr.clientssl.keystore.password";
 	public static final String RANGER_POLICYMGR_CLIENT_KEY_FILE_TYPE_DEFAULT     = "jks";
 
 	public static final String RANGER_POLICYMGR_TRUSTSTORE_FILE                  = "xasecure.policymgr.clientssl.truststore";
 	public static final String RANGER_POLICYMGR_TRUSTSTORE_FILE_TYPE             = "xasecure.policymgr.clientssl.truststore.type";
 	public static final String RANGER_POLICYMGR_TRUSTSTORE_FILE_CREDENTIAL       = "xasecure.policymgr.clientssl.truststore.credential.file";
 	public static final String RANGER_POLICYMGR_TRUSTSTORE_FILE_CREDENTIAL_ALIAS = "sslTrustStore";
+	public static final String RANGER_POLICYMGR_TRUSTSTORE_FILE_PASSWORD         = "xasecure.policymgr.clientssl.truststore.password";
 	public static final String RANGER_POLICYMGR_TRUSTSTORE_FILE_TYPE_DEFAULT     = "jks";
 
 	public static final String RANGER_SSL_KEYMANAGER_ALGO_TYPE					 = KeyManagerFactory.getDefaultAlgorithm();

--- a/agents-common/pom.xml
+++ b/agents-common/pom.xml
@@ -194,6 +194,12 @@
         </dependency>
         <!-- Test -->
         <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk15on</artifactId>
+            <version>${bouncycastle.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <version>${junit.jupiter.version}</version>

--- a/agents-common/src/main/java/org/apache/ranger/authorization/hadoop/config/RangerChainedPluginConfig.java
+++ b/agents-common/src/main/java/org/apache/ranger/authorization/hadoop/config/RangerChainedPluginConfig.java
@@ -27,7 +27,7 @@ public class RangerChainedPluginConfig extends RangerPluginConfig {
 
     private static final Logger LOG = LoggerFactory.getLogger(RangerChainedPluginConfig.class);
 
-    private final String[] legacySSLProperties           = new String[] {"xasecure.policymgr.clientssl.keystore", "xasecure.policymgr.clientssl.keystore.type", "xasecure.policymgr.clientssl.keystore.credential.file","xasecure.policymgr.clientssl.truststore", "xasecure.policymgr.clientssl.truststore.credential.file", "hadoop.security.credential.provider.path"};
+    private final String[] legacySSLProperties           = new String[] {"xasecure.policymgr.clientssl.keystore", "xasecure.policymgr.clientssl.keystore.type", "xasecure.policymgr.clientssl.keystore.credential.file", "xasecure.policymgr.clientssl.keystore.password", "xasecure.policymgr.clientssl.truststore", "xasecure.policymgr.clientssl.truststore.credential.file", "xasecure.policymgr.clientssl.truststore.password", "hadoop.security.credential.provider.path"};
     private final String[] chainedPluginPropertyPrefixes = new String[] { ".chained.services"};
 
     public RangerChainedPluginConfig(String serviceType, String serviceName, String appId, RangerPluginConfig sourcePluginConfig) {

--- a/agents-common/src/main/java/org/apache/ranger/plugin/util/RangerRESTClient.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/util/RangerRESTClient.java
@@ -77,12 +77,14 @@ public class RangerRESTClient {
 	public static final String RANGER_POLICYMGR_CLIENT_KEY_FILE_TYPE             = "xasecure.policymgr.clientssl.keystore.type";
 	public static final String RANGER_POLICYMGR_CLIENT_KEY_FILE_CREDENTIAL       = "xasecure.policymgr.clientssl.keystore.credential.file";
 	public static final String RANGER_POLICYMGR_CLIENT_KEY_FILE_CREDENTIAL_ALIAS = "sslKeyStore";
+	public static final String RANGER_POLICYMGR_CLIENT_KEY_FILE_PASSWORD         = "xasecure.policymgr.clientssl.keystore.password";
 	public static final String RANGER_POLICYMGR_CLIENT_KEY_FILE_TYPE_DEFAULT     = "jks";	
 
 	public static final String RANGER_POLICYMGR_TRUSTSTORE_FILE                  = "xasecure.policymgr.clientssl.truststore";
 	public static final String RANGER_POLICYMGR_TRUSTSTORE_FILE_TYPE             = "xasecure.policymgr.clientssl.truststore.type";	
 	public static final String RANGER_POLICYMGR_TRUSTSTORE_FILE_CREDENTIAL       = "xasecure.policymgr.clientssl.truststore.credential.file";
 	public static final String RANGER_POLICYMGR_TRUSTSTORE_FILE_CREDENTIAL_ALIAS = "sslTrustStore";
+	public static final String RANGER_POLICYMGR_TRUSTSTORE_FILE_PASSWORD         = "xasecure.policymgr.clientssl.truststore.password";
 	public static final String RANGER_POLICYMGR_TRUSTSTORE_FILE_TYPE_DEFAULT     = "jks";	
 
 	public static final String RANGER_SSL_KEYMANAGER_ALGO_TYPE					 = KeyManagerFactory.getDefaultAlgorithm();
@@ -98,12 +100,14 @@ public class RangerRESTClient {
 	private String mKeyStoreURL;
 	private String mKeyStoreAlias;
 	private String mKeyStoreFile;
+	private String mKeyStorePassword;
 	private String mKeyStoreType;
 	private String mTrustStoreURL;
 	private String mTrustStoreAlias;
 	private String mTrustStoreFile;
-	private String       mTrustStoreType;
-	private int          mRestClientConnTimeOutMs;
+	private String mTrustStorePassword;
+	private String mTrustStoreType;
+	private int    mRestClientConnTimeOutMs;
 	private int    mRestClientReadTimeOutMs;
 	private int    maxRetryAttempts;
 	private int    retryIntervalMs;
@@ -294,11 +298,13 @@ public class RangerRESTClient {
 				mKeyStoreAlias = RANGER_POLICYMGR_CLIENT_KEY_FILE_CREDENTIAL_ALIAS;
 				mKeyStoreType = config.get(RANGER_POLICYMGR_CLIENT_KEY_FILE_TYPE, RANGER_POLICYMGR_CLIENT_KEY_FILE_TYPE_DEFAULT);
 				mKeyStoreFile = config.get(RANGER_POLICYMGR_CLIENT_KEY_FILE);
+				mKeyStorePassword = config.get(RANGER_POLICYMGR_CLIENT_KEY_FILE_PASSWORD);
 
 				mTrustStoreURL = config.get(RANGER_POLICYMGR_TRUSTSTORE_FILE_CREDENTIAL);
 				mTrustStoreAlias = RANGER_POLICYMGR_TRUSTSTORE_FILE_CREDENTIAL_ALIAS;
 				mTrustStoreType = config.get(RANGER_POLICYMGR_TRUSTSTORE_FILE_TYPE, RANGER_POLICYMGR_TRUSTSTORE_FILE_TYPE_DEFAULT);
 				mTrustStoreFile = config.get(RANGER_POLICYMGR_TRUSTSTORE_FILE);
+				mTrustStorePassword = config.get(RANGER_POLICYMGR_TRUSTSTORE_FILE_PASSWORD);
 			} catch (IOException ioe) {
 				LOG.error("Unable to load SSL Config FileName: [" + mSslConfigFileName + "]", ioe);
 			} finally {
@@ -328,12 +334,16 @@ public class RangerRESTClient {
 	}
 
 	private KeyManager[] getKeyManagers() {
-		KeyManager[] kmList = null;
-
-		String keyStoreFilepwd = getCredential(mKeyStoreURL, mKeyStoreAlias);
-
-		kmList = getKeyManagers(mKeyStoreFile,keyStoreFilepwd);
-		return kmList;
+		if (StringUtils.isNotEmpty(mKeyStoreURL) && StringUtils.isNotEmpty(mKeyStoreAlias)) {
+			String keyStoreFilepwd = getCredential(mKeyStoreURL, mKeyStoreAlias);
+			if (StringUtils.isNotEmpty(keyStoreFilepwd)) {
+				return getKeyManagers(mKeyStoreFile, keyStoreFilepwd);
+			}
+		}
+		if (StringUtils.isNotEmpty(mKeyStorePassword)){
+			return getKeyManagers(mKeyStoreFile, mKeyStorePassword);
+		}
+		return null;
 	}
 
 	public KeyManager[] getKeyManagers(String keyStoreFile, String keyStoreFilePwd) {
@@ -386,14 +396,16 @@ public class RangerRESTClient {
 	}
 
 	private TrustManager[] getTrustManagers() {
-		TrustManager[] tmList = null;
 		if (StringUtils.isNotEmpty(mTrustStoreURL) && StringUtils.isNotEmpty(mTrustStoreAlias)) {
 			String trustStoreFilepwd = getCredential(mTrustStoreURL, mTrustStoreAlias);
 			if (StringUtils.isNotEmpty(trustStoreFilepwd)) {
-				tmList = getTrustManagers(mTrustStoreFile, trustStoreFilepwd);
+				return getTrustManagers(mTrustStoreFile, trustStoreFilepwd);
 			}
 		}
-		return tmList;
+		if (StringUtils.isNotEmpty(mTrustStorePassword)){
+			return getTrustManagers(mTrustStoreFile, mTrustStorePassword);
+		}
+		return null;
 	}
 
 	public TrustManager[] getTrustManagers(String trustStoreFile, String trustStoreFilepwd) {

--- a/agents-common/src/main/java/org/apache/ranger/plugin/util/RangerSslHelper.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/util/RangerSslHelper.java
@@ -52,12 +52,14 @@ public class RangerSslHelper {
 	static final String RANGER_POLICYMGR_CLIENT_KEY_FILE_TYPE             = "xasecure.policymgr.clientssl.keystore.type";
 	static final String RANGER_POLICYMGR_CLIENT_KEY_FILE_CREDENTIAL       = "xasecure.policymgr.clientssl.keystore.credential.file";
 	static final String RANGER_POLICYMGR_CLIENT_KEY_FILE_CREDENTIAL_ALIAS = "sslKeyStore";
+	static final String RANGER_POLICYMGR_CLIENT_KEY_FILE_PASSWORD         = "xasecure.policymgr.clientssl.keystore.password";
 	static final String RANGER_POLICYMGR_CLIENT_KEY_FILE_TYPE_DEFAULT     = "jks";	
 
 	static final String RANGER_POLICYMGR_TRUSTSTORE_FILE                  = "xasecure.policymgr.clientssl.truststore";	
 	static final String RANGER_POLICYMGR_TRUSTSTORE_FILE_TYPE             = "xasecure.policymgr.clientssl.truststore.type";	
 	static final String RANGER_POLICYMGR_TRUSTSTORE_FILE_CREDENTIAL       = "xasecure.policymgr.clientssl.truststore.credential.file";
 	static final String RANGER_POLICYMGR_TRUSTSTORE_FILE_CREDENTIAL_ALIAS = "sslTrustStore";
+	static final String RANGER_POLICYMGR_TRUSTSTORE_FILE_PASSWORD         = "xasecure.policymgr.clientssl.truststore.password";
 	static final String RANGER_POLICYMGR_TRUSTSTORE_FILE_TYPE_DEFAULT     = "jks";	
 
 	static final String RANGER_SSL_KEYMANAGER_ALGO_TYPE                   = KeyManagerFactory.getDefaultAlgorithm();
@@ -67,10 +69,12 @@ public class RangerSslHelper {
 	private String mKeyStoreURL;
 	private String mKeyStoreAlias;
 	private String mKeyStoreFile;
+	private String mKeyStorePassword;
 	private String mKeyStoreType;
 	private String mTrustStoreURL;
 	private String mTrustStoreAlias;
 	private String mTrustStoreFile;
+	private String mTrustStorePassword;
 	private String mTrustStoreType;
 
 	final static HostnameVerifier _Hv = new HostnameVerifier() {
@@ -120,11 +124,13 @@ public class RangerSslHelper {
 			mKeyStoreAlias = RANGER_POLICYMGR_CLIENT_KEY_FILE_CREDENTIAL_ALIAS;
 			mKeyStoreType  = conf.get(RANGER_POLICYMGR_CLIENT_KEY_FILE_TYPE, RANGER_POLICYMGR_CLIENT_KEY_FILE_TYPE_DEFAULT);
 			mKeyStoreFile  = conf.get(RANGER_POLICYMGR_CLIENT_KEY_FILE);
+			mKeyStorePassword = conf.get(RANGER_POLICYMGR_CLIENT_KEY_FILE_PASSWORD);
 
 			mTrustStoreURL   = conf.get(RANGER_POLICYMGR_TRUSTSTORE_FILE_CREDENTIAL);
 			mTrustStoreAlias = RANGER_POLICYMGR_TRUSTSTORE_FILE_CREDENTIAL_ALIAS;
 			mTrustStoreType  = conf.get(RANGER_POLICYMGR_TRUSTSTORE_FILE_TYPE, RANGER_POLICYMGR_TRUSTSTORE_FILE_TYPE_DEFAULT);
 			mTrustStoreFile  = conf.get(RANGER_POLICYMGR_TRUSTSTORE_FILE);
+			mTrustStorePassword = conf.get(RANGER_POLICYMGR_TRUSTSTORE_FILE_PASSWORD);
 
 			if (LOG.isDebugEnabled()) {
 				LOG.debug(toString());
@@ -141,7 +147,13 @@ public class RangerSslHelper {
 	private KeyManager[] getKeyManagers() {
 		KeyManager[] kmList = null;
 
-		String keyStoreFilepwd = getCredential(mKeyStoreURL, mKeyStoreAlias);
+		String keyStoreFilepwd = "";
+
+		if (!StringUtil.isEmpty(mKeyStoreURL) && !StringUtil.isEmpty(mKeyStoreAlias)) {
+			keyStoreFilepwd = getCredential(mKeyStoreURL, mKeyStoreAlias);
+		} else if (!StringUtil.isEmpty(mKeyStorePassword)) {
+			keyStoreFilepwd = mKeyStorePassword;
+		}
 
 		if (!StringUtil.isEmpty(mKeyStoreFile) && !StringUtil.isEmpty(keyStoreFilepwd)) {
 			InputStream in =  null;
@@ -185,7 +197,13 @@ public class RangerSslHelper {
 	private TrustManager[] getTrustManagers() {
 		TrustManager[] tmList = null;
 
-		String trustStoreFilepwd = getCredential(mTrustStoreURL, mTrustStoreAlias);
+		String trustStoreFilepwd = "";
+
+		if (!StringUtil.isEmpty(mTrustStoreURL) && !StringUtil.isEmpty(mTrustStoreAlias)) {
+			trustStoreFilepwd = getCredential(mTrustStoreURL, mTrustStoreAlias);
+		} else if (!StringUtil.isEmpty(mTrustStorePassword)) {
+			trustStoreFilepwd = mTrustStorePassword;
+		}
 
 		if (!StringUtil.isEmpty(mTrustStoreFile) && !StringUtil.isEmpty(trustStoreFilepwd)) {
 			InputStream in =  null;

--- a/agents-common/src/test/java/org/apache/ranger/plugin/util/RangerRESTClientSSLPasswordTest.java
+++ b/agents-common/src/test/java/org/apache/ranger/plugin/util/RangerRESTClientSSLPasswordTest.java
@@ -1,0 +1,242 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ranger.plugin.util;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.math.BigInteger;
+import java.security.*;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+import java.util.Date;
+
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.security.alias.CredentialProvider;
+import org.apache.hadoop.security.alias.CredentialProviderFactory;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x500.style.RFC4519Style;
+import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
+import org.bouncycastle.cert.X509v3CertificateBuilder;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+
+public class RangerRESTClientSSLPasswordTest {
+
+    private static final String KEYSTORE_PASSWORD = "keystorePass123";
+    private static final String TRUSTSTORE_PASSWORD = "truststorePass456";
+
+    private File keystoreFile;
+    private File truststoreFile;
+    private File jceksFile;
+    private Configuration config;
+    private String jceksPath;
+
+    @Before
+    public void setUp() throws Exception {
+        keystoreFile = createTempKeyStore(KEYSTORE_PASSWORD);
+        truststoreFile = createTempKeyStore(TRUSTSTORE_PASSWORD);
+
+        // Create a temporary JCEKS file with credentials
+        jceksFile = File.createTempFile("ranger-test", ".jceks");
+        jceksFile.deleteOnExit();
+
+        // Set up Hadoop configuration with the JCEKS provider path
+        Configuration hadoopConf = new Configuration();
+        jceksPath = "localjceks://file/" + jceksFile.getAbsolutePath();
+        hadoopConf.set(CredentialProviderFactory.CREDENTIAL_PROVIDER_PATH, jceksPath);
+
+        // Store credentials in the JCEKS file
+        CredentialProvider provider = CredentialProviderFactory.getProviders(hadoopConf).get(0);
+        provider.createCredentialEntry(
+                RangerRESTClient.RANGER_POLICYMGR_CLIENT_KEY_FILE_CREDENTIAL_ALIAS,
+                KEYSTORE_PASSWORD.toCharArray());
+        provider.createCredentialEntry(
+                RangerRESTClient.RANGER_POLICYMGR_TRUSTSTORE_FILE_CREDENTIAL_ALIAS,
+                TRUSTSTORE_PASSWORD.toCharArray());
+        provider.flush();
+
+        config = new Configuration();
+        config.set(RangerRESTClient.RANGER_POLICYMGR_CLIENT_KEY_FILE, keystoreFile.getAbsolutePath());
+        config.set(RangerRESTClient.RANGER_POLICYMGR_TRUSTSTORE_FILE, truststoreFile.getAbsolutePath());
+        config.set(RangerRESTClient.RANGER_POLICYMGR_CLIENT_KEY_FILE_TYPE, "jks");
+        config.set(RangerRESTClient.RANGER_POLICYMGR_TRUSTSTORE_FILE_TYPE, "jks");
+    }
+
+    @After
+    public void tearDown() {
+        if (keystoreFile != null && keystoreFile.exists()) {
+            keystoreFile.delete();
+        }
+        if (truststoreFile != null && truststoreFile.exists()) {
+            truststoreFile.delete();
+        }
+        if (jceksFile != null && jceksFile.exists()) {
+            jceksFile.delete();
+        }
+    }
+
+    @Test
+    public void testKeyAndTrustStorePasswordsFromConfig() {
+        config.set(RangerRESTClient.RANGER_POLICYMGR_CLIENT_KEY_FILE_PASSWORD, KEYSTORE_PASSWORD);
+        config.set(RangerRESTClient.RANGER_POLICYMGR_TRUSTSTORE_FILE_PASSWORD, TRUSTSTORE_PASSWORD);
+
+        RangerRESTClient client = new RangerRESTClient("https://localhost:6182", null, config);
+
+        KeyManager[] keyManagers = client.getKeyManagers(keystoreFile.getAbsolutePath(), KEYSTORE_PASSWORD);
+        TrustManager[] trustManagers = client.getTrustManagers(truststoreFile.getAbsolutePath(), TRUSTSTORE_PASSWORD);
+
+        assertNotNull("KeyManagers should not be null with correct password", keyManagers);
+        assertTrue("KeyManagers should contain at least one entry", keyManagers.length > 0);
+        assertNotNull("TrustManagers should not be null with correct password", trustManagers);
+        assertTrue("TrustManagers should contain at least one entry", trustManagers.length > 0);
+    }
+
+    @Test
+    public void testSSLContextCreationWithCorrectPasswords() {
+        config.set(RangerRESTClient.RANGER_POLICYMGR_CLIENT_KEY_FILE_PASSWORD, KEYSTORE_PASSWORD);
+        config.set(RangerRESTClient.RANGER_POLICYMGR_TRUSTSTORE_FILE_PASSWORD, TRUSTSTORE_PASSWORD);
+
+        RangerRESTClient client = new RangerRESTClient("https://localhost:6182", null, config);
+        KeyManager[] km = client.getKeyManagers(keystoreFile.getAbsolutePath(), KEYSTORE_PASSWORD);
+        TrustManager[] tm = client.getTrustManagers(truststoreFile.getAbsolutePath(), TRUSTSTORE_PASSWORD);
+        SSLContext sslContext = client.getSSLContext(km, tm);
+
+        assertNotNull(sslContext);
+
+        assertNotNull("Client should be built successfully", client.getClient());
+    }
+
+    @Test
+    public void testKeyStorePasswordIncorrectJCEKSPrecedence() {
+        config.set(RangerRESTClient.RANGER_POLICYMGR_CLIENT_KEY_FILE_PASSWORD, "wrongPassword");
+        config.set(RangerRESTClient.RANGER_POLICYMGR_CLIENT_KEY_FILE_CREDENTIAL, jceksPath);
+        config.set(RangerRESTClient.RANGER_POLICYMGR_TRUSTSTORE_FILE_PASSWORD, "wrongPassword");
+        config.set(RangerRESTClient.RANGER_POLICYMGR_TRUSTSTORE_FILE_CREDENTIAL, jceksPath);
+
+        RangerRESTClient client = new RangerRESTClient("https://localhost:6182", null, config);
+
+        assertNotNull("Client should be built successfully", client.getClient());
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testKeyStorePasswordIncorrect() {
+        config.set(RangerRESTClient.RANGER_POLICYMGR_CLIENT_KEY_FILE_PASSWORD, "wrongPassword");
+        config.set(RangerRESTClient.RANGER_POLICYMGR_TRUSTSTORE_FILE_PASSWORD, TRUSTSTORE_PASSWORD);
+
+        RangerRESTClient client = new RangerRESTClient("https://localhost:6182", null, config);
+
+        // Should throw exception
+        client.getClient();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testTrustStorePasswordIncorrect() {
+        config.set(RangerRESTClient.RANGER_POLICYMGR_CLIENT_KEY_FILE_PASSWORD, KEYSTORE_PASSWORD);
+        config.set(RangerRESTClient.RANGER_POLICYMGR_TRUSTSTORE_FILE_PASSWORD, "wrongPassword");
+
+        RangerRESTClient client = new RangerRESTClient("https://localhost:6182", null, config);
+
+        // Should throw exception
+        client.getClient();
+    }
+
+    @Test
+    public void testBuildClientWithCorrectPasswords() {
+        config.set(RangerRESTClient.RANGER_POLICYMGR_CLIENT_KEY_FILE_PASSWORD, KEYSTORE_PASSWORD);
+        config.set(RangerRESTClient.RANGER_POLICYMGR_TRUSTSTORE_FILE_PASSWORD, TRUSTSTORE_PASSWORD);
+
+        RangerRESTClient client = new RangerRESTClient("https://localhost:6182", null, config);
+
+        assertNotNull("Client should be built successfully", client.getClient());
+    }
+
+    @Test
+    public void testClientBuiltSuccessfullyEvenWithMissingTrustPassword() {
+        // Missing truststore password should not prevent client creation (falls back to default)
+        config.set(RangerRESTClient.RANGER_POLICYMGR_CLIENT_KEY_FILE_PASSWORD, KEYSTORE_PASSWORD);
+        // truststore password not set
+
+        RangerRESTClient client = new RangerRESTClient("https://localhost:6182", null, config);
+        // Should build client without throwing exception
+        assertNotNull(client.getClient());
+    }
+
+    @Test
+    public void testClientBuiltSuccessfullyEvenWithMissingKeystorePassword() {
+        // Missing keystore password should not prevent client creation (falls back to default)
+        config.set(RangerRESTClient.RANGER_POLICYMGR_TRUSTSTORE_FILE_PASSWORD, TRUSTSTORE_PASSWORD);
+        // keystore password not set
+
+        RangerRESTClient client = new RangerRESTClient("https://localhost:6182", null, config);
+        // Should build client without throwing exception
+        assertNotNull(client.getClient());
+    }
+
+    /**
+     * Creates a temporary JKS keystore containing a single private key entry
+     * with a self-signed certificate.
+     */
+    private File createTempKeyStore(String password) throws Exception {
+        KeyStore ks = KeyStore.getInstance("JKS");
+        ks.load(null, password.toCharArray());
+
+        // Generate a key pair
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+        kpg.initialize(2048);
+        KeyPair kp = kpg.generateKeyPair();
+
+        // Generate a self-signed X.509 certificate
+        X509Certificate cert = generateSelfSignedCertificate(kp);
+
+        // Store the private key with the certificate chain
+        ks.setKeyEntry("alias", kp.getPrivate(), password.toCharArray(),
+                new Certificate[]{cert});
+
+        File tempFile = File.createTempFile("test", ".jks");
+        tempFile.deleteOnExit();
+        try (FileOutputStream fos = new FileOutputStream(tempFile)) {
+            ks.store(fos, password.toCharArray());
+        }
+        return tempFile;
+    }
+
+
+    // Minimal self-signed certificate generation (for test purposes only)
+    private X509Certificate generateSelfSignedCertificate(KeyPair keyPair) throws Exception {
+        Date currentDate = new Date();
+        Date expiryDate = new Date(currentDate.getTime() + 365L * 24L * 60L * 60L * 1000L);
+
+        // Create X509Certificate
+        X509v3CertificateBuilder certBuilder =
+                new X509v3CertificateBuilder(new X500Name(RFC4519Style.INSTANCE, "CN=Test"), BigInteger.valueOf(30), currentDate, expiryDate,
+                        new X500Name(RFC4519Style.INSTANCE, "CN=Test"), SubjectPublicKeyInfo.getInstance(keyPair.getPublic().getEncoded()));
+        ContentSigner contentSigner = new JcaContentSignerBuilder("SHA256WithRSAEncryption").build(keyPair.getPrivate());
+        return new JcaX509CertificateConverter().getCertificate(certBuilder.build(contentSigner));
+    }
+}

--- a/agents-common/src/test/java/org/apache/ranger/plugin/util/RangerSslHelperSSLPasswordTest.java
+++ b/agents-common/src/test/java/org/apache/ranger/plugin/util/RangerSslHelperSSLPasswordTest.java
@@ -1,0 +1,260 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ranger.plugin.util;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.math.BigInteger;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.KeyStore;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+import java.util.Date;
+
+import javax.net.ssl.SSLContext;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.security.alias.CredentialProvider;
+import org.apache.hadoop.security.alias.CredentialProviderFactory;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x500.style.RFC4519Style;
+import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
+import org.bouncycastle.cert.X509v3CertificateBuilder;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class RangerSslHelperSSLPasswordTest {
+
+    private static final String KEYSTORE_PASSWORD = "keystorePass123";
+    private static final String TRUSTSTORE_PASSWORD = "truststorePass456";
+
+    private File keystoreFile;
+    private File truststoreFile;
+    private File jceksFile;
+    private String jceksPath;
+
+    @Before
+    public void setUp() throws Exception {
+        keystoreFile = createTempKeyStore(KEYSTORE_PASSWORD);
+        truststoreFile = createTempKeyStore(TRUSTSTORE_PASSWORD);
+
+        // Create a temporary JCEKS file with credentials
+        jceksFile = File.createTempFile("ranger-test", ".jceks");
+        jceksFile.deleteOnExit();
+
+        Configuration hadoopConf = new Configuration();
+        jceksPath = "localjceks://file/" + jceksFile.getAbsolutePath();
+        hadoopConf.set(CredentialProviderFactory.CREDENTIAL_PROVIDER_PATH, jceksPath);
+
+        CredentialProvider provider = CredentialProviderFactory.getProviders(hadoopConf).get(0);
+        provider.createCredentialEntry(
+                RangerSslHelper.RANGER_POLICYMGR_CLIENT_KEY_FILE_CREDENTIAL_ALIAS,
+                KEYSTORE_PASSWORD.toCharArray());
+        provider.createCredentialEntry(
+                RangerSslHelper.RANGER_POLICYMGR_TRUSTSTORE_FILE_CREDENTIAL_ALIAS,
+                TRUSTSTORE_PASSWORD.toCharArray());
+        provider.flush();
+    }
+
+    @After
+    public void tearDown() {
+        if (keystoreFile != null && keystoreFile.exists()) {
+            keystoreFile.delete();
+        }
+        if (truststoreFile != null && truststoreFile.exists()) {
+            truststoreFile.delete();
+        }
+        if (jceksFile != null && jceksFile.exists()) {
+            jceksFile.delete();
+        }
+    }
+
+    @Test
+    public void testSSLContextCreationWithCorrectPasswords() throws Exception {
+        Configuration conf = new Configuration(false);
+        conf.set(RangerSslHelper.RANGER_POLICYMGR_CLIENT_KEY_FILE, keystoreFile.getAbsolutePath());
+        conf.set(RangerSslHelper.RANGER_POLICYMGR_TRUSTSTORE_FILE, truststoreFile.getAbsolutePath());
+        conf.set(RangerSslHelper.RANGER_POLICYMGR_CLIENT_KEY_FILE_TYPE, "jks");
+        conf.set(RangerSslHelper.RANGER_POLICYMGR_TRUSTSTORE_FILE_TYPE, "jks");
+        conf.set(RangerSslHelper.RANGER_POLICYMGR_CLIENT_KEY_FILE_PASSWORD, KEYSTORE_PASSWORD);
+        conf.set(RangerSslHelper.RANGER_POLICYMGR_TRUSTSTORE_FILE_PASSWORD, TRUSTSTORE_PASSWORD);
+
+        File configFile = writeConfigurationToFile(conf);
+        RangerSslHelper helper = new RangerSslHelper(configFile.getAbsolutePath());
+
+        SSLContext sslContext = helper.createContext();
+        assertNotNull("SSLContext should be created with correct passwords", sslContext);
+        configFile.delete();
+    }
+
+    @Test
+    public void testSSLContextFailsWithIncorrectTruststorePassword() throws Exception {
+        Configuration conf = new Configuration(false);
+        conf.set(RangerSslHelper.RANGER_POLICYMGR_CLIENT_KEY_FILE, keystoreFile.getAbsolutePath());
+        conf.set(RangerSslHelper.RANGER_POLICYMGR_TRUSTSTORE_FILE, truststoreFile.getAbsolutePath());
+        conf.set(RangerSslHelper.RANGER_POLICYMGR_CLIENT_KEY_FILE_TYPE, "jks");
+        conf.set(RangerSslHelper.RANGER_POLICYMGR_TRUSTSTORE_FILE_TYPE, "jks");
+        conf.set(RangerSslHelper.RANGER_POLICYMGR_CLIENT_KEY_FILE_PASSWORD, KEYSTORE_PASSWORD);
+        conf.set(RangerSslHelper.RANGER_POLICYMGR_TRUSTSTORE_FILE_PASSWORD, "wrongPassword");
+
+        File configFile = writeConfigurationToFile(conf);
+        RangerSslHelper helper = new RangerSslHelper(configFile.getAbsolutePath());
+
+        SSLContext sslContext = helper.createContext();
+        assertNull("SSLContext should be null when truststore password is incorrect", sslContext);
+        configFile.delete();
+    }
+
+    @Test
+    public void testSSLContextCreatedEvenWithMissingKeystorePassword() throws Exception {
+        // Keystore password missing → keystore loading is skipped; truststore alone may succeed.
+        Configuration conf = new Configuration(false);
+        conf.set(RangerSslHelper.RANGER_POLICYMGR_CLIENT_KEY_FILE, keystoreFile.getAbsolutePath());
+        conf.set(RangerSslHelper.RANGER_POLICYMGR_TRUSTSTORE_FILE, truststoreFile.getAbsolutePath());
+        conf.set(RangerSslHelper.RANGER_POLICYMGR_CLIENT_KEY_FILE_TYPE, "jks");
+        conf.set(RangerSslHelper.RANGER_POLICYMGR_TRUSTSTORE_FILE_TYPE, "jks");
+        // No keystore password
+        conf.set(RangerSslHelper.RANGER_POLICYMGR_TRUSTSTORE_FILE_PASSWORD, TRUSTSTORE_PASSWORD);
+
+        File configFile = writeConfigurationToFile(conf);
+        RangerSslHelper helper = new RangerSslHelper(configFile.getAbsolutePath());
+
+        SSLContext sslContext = helper.createContext();
+        assertNotNull("SSLContext should be created using only truststore", sslContext);
+        configFile.delete();
+    }
+
+    @Test
+    public void testSSLContextCreatedEvenWithMissingTruststorePassword() throws Exception {
+        // Truststore password missing → truststore loading skipped; keystore alone may succeed.
+        Configuration conf = new Configuration(false);
+        conf.set(RangerSslHelper.RANGER_POLICYMGR_CLIENT_KEY_FILE, keystoreFile.getAbsolutePath());
+        conf.set(RangerSslHelper.RANGER_POLICYMGR_TRUSTSTORE_FILE, truststoreFile.getAbsolutePath());
+        conf.set(RangerSslHelper.RANGER_POLICYMGR_CLIENT_KEY_FILE_TYPE, "jks");
+        conf.set(RangerSslHelper.RANGER_POLICYMGR_TRUSTSTORE_FILE_TYPE, "jks");
+        conf.set(RangerSslHelper.RANGER_POLICYMGR_CLIENT_KEY_FILE_PASSWORD, KEYSTORE_PASSWORD);
+        // No truststore password
+
+        File configFile = writeConfigurationToFile(conf);
+        RangerSslHelper helper = new RangerSslHelper(configFile.getAbsolutePath());
+
+        SSLContext sslContext = helper.createContext();
+        assertNull("SSLContext should not be created using only keystore", sslContext);
+        configFile.delete();
+    }
+
+    @Test
+    public void testSSLContextFromJceksCredentials() throws Exception {
+        Configuration conf = new Configuration(false);
+        conf.set(RangerSslHelper.RANGER_POLICYMGR_CLIENT_KEY_FILE, keystoreFile.getAbsolutePath());
+        conf.set(RangerSslHelper.RANGER_POLICYMGR_TRUSTSTORE_FILE, truststoreFile.getAbsolutePath());
+        conf.set(RangerSslHelper.RANGER_POLICYMGR_CLIENT_KEY_FILE_TYPE, "jks");
+        conf.set(RangerSslHelper.RANGER_POLICYMGR_TRUSTSTORE_FILE_TYPE, "jks");
+        conf.set(RangerSslHelper.RANGER_POLICYMGR_CLIENT_KEY_FILE_CREDENTIAL, jceksPath);
+        conf.set(RangerSslHelper.RANGER_POLICYMGR_TRUSTSTORE_FILE_CREDENTIAL, jceksPath);
+        // No direct passwords
+
+        File configFile = writeConfigurationToFile(conf);
+        RangerSslHelper helper = new RangerSslHelper(configFile.getAbsolutePath());
+
+        SSLContext sslContext = helper.createContext();
+        assertNotNull("SSLContext should be created using JCEKS credentials", sslContext);
+        configFile.delete();
+    }
+
+    @Test
+    public void testJceksPrecedenceOverIncorrectDirectPassword() throws Exception {
+        Configuration conf = new Configuration(false);
+        conf.set(RangerSslHelper.RANGER_POLICYMGR_CLIENT_KEY_FILE, keystoreFile.getAbsolutePath());
+        conf.set(RangerSslHelper.RANGER_POLICYMGR_TRUSTSTORE_FILE, truststoreFile.getAbsolutePath());
+        conf.set(RangerSslHelper.RANGER_POLICYMGR_CLIENT_KEY_FILE_TYPE, "jks");
+        conf.set(RangerSslHelper.RANGER_POLICYMGR_TRUSTSTORE_FILE_TYPE, "jks");
+        // Incorrect direct passwords
+        conf.set(RangerSslHelper.RANGER_POLICYMGR_CLIENT_KEY_FILE_PASSWORD, "wrongPassword");
+        conf.set(RangerSslHelper.RANGER_POLICYMGR_TRUSTSTORE_FILE_PASSWORD, "wrongPassword");
+        // Correct JCEKS credentials
+        conf.set(RangerSslHelper.RANGER_POLICYMGR_CLIENT_KEY_FILE_CREDENTIAL, jceksPath);
+        conf.set(RangerSslHelper.RANGER_POLICYMGR_TRUSTSTORE_FILE_CREDENTIAL, jceksPath);
+
+        File configFile = writeConfigurationToFile(conf);
+        RangerSslHelper helper = new RangerSslHelper(configFile.getAbsolutePath());
+
+        SSLContext sslContext = helper.createContext();
+        assertNotNull("SSLContext should succeed because JCEKS password takes precedence", sslContext);
+        configFile.delete();
+    }
+
+    // Writes a Configuration object to a temporary Hadoop XML file.
+    private File writeConfigurationToFile(Configuration conf) throws Exception {
+        File tempFile = File.createTempFile("ranger-ssl", ".xml");
+        tempFile.deleteOnExit();
+        try (FileOutputStream fos = new FileOutputStream(tempFile)) {
+            conf.writeXml(fos);
+        }
+        return tempFile;
+    }
+
+    // Creates a temporary JKS keystore with a self‑signed certificate.
+    private File createTempKeyStore(String password) throws Exception {
+        KeyStore ks = KeyStore.getInstance("JKS");
+        ks.load(null, password.toCharArray());
+
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+        kpg.initialize(2048);
+        KeyPair kp = kpg.generateKeyPair();
+
+        X509Certificate cert = generateSelfSignedCertificate(kp);
+
+        ks.setKeyEntry("alias", kp.getPrivate(), password.toCharArray(),
+                new Certificate[]{cert});
+
+        File tempFile = File.createTempFile("test", ".jks");
+        tempFile.deleteOnExit();
+        try (FileOutputStream fos = new FileOutputStream(tempFile)) {
+            ks.store(fos, password.toCharArray());
+        }
+        return tempFile;
+    }
+
+    // Generates a self‑signed X.509 certificate using Bouncy Castle.
+    private X509Certificate generateSelfSignedCertificate(KeyPair keyPair) throws Exception {
+        Date currentDate = new Date();
+        Date expiryDate = new Date(currentDate.getTime() + 365L * 24L * 60L * 60L * 1000L);
+
+        X509v3CertificateBuilder certBuilder = new X509v3CertificateBuilder(
+                new X500Name(RFC4519Style.INSTANCE, "CN=Test"),
+                BigInteger.valueOf(System.currentTimeMillis()),
+                currentDate,
+                expiryDate,
+                new X500Name(RFC4519Style.INSTANCE, "CN=Test"),
+                SubjectPublicKeyInfo.getInstance(keyPair.getPublic().getEncoded()));
+
+        ContentSigner contentSigner = new JcaContentSignerBuilder("SHA256WithRSAEncryption")
+                .build(keyPair.getPrivate());
+
+        return new JcaX509CertificateConverter().getCertificate(certBuilder.build(contentSigner));
+    }
+}

--- a/plugin-trino/src/main/java/org/apache/ranger/services/trino/RangerServiceTrino.java
+++ b/plugin-trino/src/main/java/org/apache/ranger/services/trino/RangerServiceTrino.java
@@ -13,12 +13,9 @@
  */
 package org.apache.ranger.services.trino;
 
-import org.apache.commons.lang.StringUtils;
 import org.apache.ranger.plugin.client.HadoopConfigHolder;
 import org.apache.ranger.plugin.client.HadoopException;
 import org.apache.ranger.plugin.model.RangerPolicy;
-import org.apache.ranger.plugin.model.RangerPolicy.RangerPolicyItem;
-import org.apache.ranger.plugin.model.RangerPolicy.RangerPolicyItemAccess;
 import org.apache.ranger.plugin.service.RangerBaseService;
 import org.apache.ranger.plugin.service.ResourceLookupContext;
 import org.apache.ranger.services.trino.client.TrinoResourceManager;
@@ -26,7 +23,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;


### PR DESCRIPTION
Let's support `xasecure.policymgr.clientssl.truststore.password` and `xasecure.policymgr.clientssl.keystore.password` options for ranger plugins.