### PR TITLE
ADH-8121 Add Execute permission for Trino policy

### DIFF
--- a/agents-common/src/main/resources/service-defs/ranger-servicedef-trino.json
+++ b/agents-common/src/main/resources/service-defs/ranger-servicedef-trino.json
@@ -218,7 +218,7 @@
       "matcherOptions":         { "wildCard": true, "ignoreCase": true },
       "label":                  "Schema Function",
       "description":            "Schema Function",
-      "accessTypeRestrictions": [ "create", "drop", "show" ]
+      "accessTypeRestrictions": [ "create", "drop", "show", "execute", "grant" ]
     },
     {
       "itemId":                 11,

--- a/plugin-trino/src/test/java/org/apache/ranger/authorization/trino/authorizer/RangerTrinoPluginTest.java
+++ b/plugin-trino/src/test/java/org/apache/ranger/authorization/trino/authorizer/RangerTrinoPluginTest.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Tests for Trino plugin policy evaluation using {@link RangerBasePlugin}.
+ *
+ * <p>Loads policies from {@code trino-policies.json} and verifies that the
+ * {@code execute} permission works correctly for {@code schemafunction} resources
+ * (needed for Trino pushdown queries like {@code SELECT * FROM TABLE(oracle.system.query(...))}).
+ *
+ * <p>Also includes regression checks for {@code execute} on {@code procedure} and {@code function}.
+ */
+package org.apache.ranger.authorization.trino.authorizer;
+
+import org.apache.ranger.authorization.hadoop.config.RangerPluginConfig;
+import org.apache.ranger.plugin.policyengine.RangerAccessRequestImpl;
+import org.apache.ranger.plugin.policyengine.RangerAccessResourceImpl;
+import org.apache.ranger.plugin.policyengine.RangerAccessResult;
+import org.apache.ranger.plugin.policyengine.RangerPolicyEngineOptions;
+import org.apache.ranger.plugin.service.RangerBasePlugin;
+import org.apache.ranger.plugin.util.RangerRoles;
+import org.apache.ranger.plugin.util.RangerUserStore;
+import org.apache.ranger.plugin.util.ServicePolicies;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.Date;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RangerTrinoPluginTest {
+    private static RangerBasePlugin plugin;
+
+    @BeforeAll
+    static void setUp() {
+        Gson gson = new GsonBuilder().setDateFormat("yyyyMMdd-HH:mm:ss.SSSZ")
+                .setPrettyPrinting()
+                .create();
+
+        InputStream inStream = RangerTrinoPluginTest.class.getResourceAsStream("/trino-policies.json");
+        assertNotNull(inStream, "trino-policies.json not found on classpath");
+
+        ServicePolicies policies = gson.fromJson(new InputStreamReader(inStream), ServicePolicies.class);
+        assertNotNull(policies, "failed to parse ServicePolicies");
+
+        RangerPolicyEngineOptions peOptions = new RangerPolicyEngineOptions();
+        peOptions.disablePolicyRefresher    = true;
+        peOptions.disableTagRetriever       = true;
+        peOptions.disableUserStoreRetriever = true;
+
+        RangerPluginConfig pluginConfig = new RangerPluginConfig("trino", "cl1_trino", "trino", "cl1", "on-prem", peOptions);
+        plugin = new RangerBasePlugin(pluginConfig, policies, null, new RangerRoles(), new RangerUserStore());
+    }
+
+    /** User alice has an explicit policy granting execute on schemafunction=query — access should be allowed. */
+    @Test
+    void aliceExecuteSchemaFunctionAllowed() {
+        RangerAccessResourceImpl resource = new RangerAccessResourceImpl();
+        resource.setValue("catalog", "alice-catalog");
+        resource.setValue("schema", "schema");
+        resource.setValue("schemafunction", "query");
+
+        RangerAccessRequestImpl request = new RangerAccessRequestImpl(resource, "execute", "alice", null, null);
+        request.setAccessTime(new Date());
+
+        RangerAccessResult result = plugin.isAccessAllowed(request);
+
+        assertNotNull(result, "result should not be null");
+        assertTrue(result.getIsAllowed(), "alice should be allowed to execute schemafunction=query");
+    }
+
+    /** User bob has no policy for schemafunction — access should be denied. */
+    @Test
+    void bobExecuteSchemaFunctionDenied() {
+        RangerAccessResourceImpl resource = new RangerAccessResourceImpl();
+        resource.setValue("catalog", "alice-catalog");
+        resource.setValue("schema", "schema");
+        resource.setValue("schemafunction", "query");
+
+        RangerAccessRequestImpl request = new RangerAccessRequestImpl(resource, "execute", "bob", null, null);
+        request.setAccessTime(new Date());
+
+        RangerAccessResult result = plugin.isAccessAllowed(request);
+
+        assertNotNull(result, "result should not be null");
+        assertFalse(result.getIsAllowed(), "bob should NOT be allowed to execute schemafunction=query");
+    }
+
+    /** Regression: execute on procedure must still work after adding schemafunction support. */
+    @Test
+    void aliceExecuteProcedureAllowed() {
+        RangerAccessResourceImpl resource = new RangerAccessResourceImpl();
+        resource.setValue("catalog", "alice-catalog");
+        resource.setValue("schema", "schema");
+        resource.setValue("procedure", "procedure");
+
+        RangerAccessRequestImpl request = new RangerAccessRequestImpl(resource, "execute", "alice", null, null);
+        request.setAccessTime(new Date());
+
+        RangerAccessResult result = plugin.isAccessAllowed(request);
+
+        assertNotNull(result, "result should not be null");
+        assertTrue(result.getIsAllowed(), "alice should be allowed to execute procedure (regression check)");
+    }
+
+    /** Regression: execute on function must still work after adding schemafunction support. */
+    @Test
+    void aliceExecuteFunctionAllowed() {
+        RangerAccessResourceImpl resource = new RangerAccessResourceImpl();
+        resource.setValue("function", "function");
+
+        RangerAccessRequestImpl request = new RangerAccessRequestImpl(resource, "execute", "alice", null, null);
+        request.setAccessTime(new Date());
+
+        RangerAccessResult result = plugin.isAccessAllowed(request);
+
+        assertNotNull(result, "result should not be null");
+        assertTrue(result.getIsAllowed(), "alice should be allowed to execute function (regression check)");
+    }
+}

--- a/plugin-trino/src/test/java/org/apache/ranger/authorization/trino/authorizer/RangerTrinoPluginTest.java
+++ b/plugin-trino/src/test/java/org/apache/ranger/authorization/trino/authorizer/RangerTrinoPluginTest.java
@@ -56,7 +56,7 @@ class RangerTrinoPluginTest {
 
     @BeforeAll
     static void setUp() {
-        Gson gson = new GsonBuilder().setDateFormat("yyyyMMdd-HH:mm:ss.SSSZ")
+        Gson gson = new GsonBuilder().setDateFormat("yyyyMMdd-HH:mm:ss.SSS-Z")
                 .setPrettyPrinting()
                 .create();
 

--- a/plugin-trino/src/test/resources/trino-policies.json
+++ b/plugin-trino/src/test/resources/trino-policies.json
@@ -411,6 +411,69 @@
     },
     {
       "service": "cl1_trino",
+      "name": "alice-schemafunction",
+      "policyType": 0,
+      "policyPriority": 0,
+      "description": "",
+      "isAuditEnabled": true,
+      "resources": {
+        "catalog": {
+          "values": [
+            "alice-catalog"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        },
+        "schema": {
+          "values": [
+            "schema"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        },
+        "schemafunction": {
+          "values": [
+            "query"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        }
+      },
+      "policyItems": [
+        {
+          "accesses": [
+            {
+              "type": "execute",
+              "isAllowed": true
+            }
+          ],
+          "users": [
+            "alice"
+          ],
+          "groups": [],
+          "roles": [],
+          "conditions": [],
+          "delegateAdmin": false
+        }
+      ],
+      "denyPolicyItems": [],
+      "allowExceptions": [],
+      "denyExceptions": [],
+      "dataMaskPolicyItems": [],
+      "rowFilterPolicyItems": [],
+      "serviceType": "trino",
+      "options": {},
+      "validitySchedules": [],
+      "policyLabels": [],
+      "zoneName": "",
+      "isDenyAllElse": false,
+      "id": 58,
+      "guid": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+      "isEnabled": true,
+      "version": 1
+    },
+    {
+      "service": "cl1_trino",
       "name": "alice-view",
       "policyType": 0,
       "policyPriority": 0,
@@ -944,6 +1007,28 @@
         "label": "Schema Procedure",
         "description": "Schema Procedure",
         "accessTypeRestrictions": ["execute", "grant"]
+      },
+      {
+        "itemId": 10,
+        "name": "schemafunction",
+        "type": "string",
+        "level": 30,
+        "parent": "schema",
+        "mandatory": true,
+        "lookupSupported": false,
+        "recursiveSupported": false,
+        "excludesSupported": false,
+        "matcher": "org.apache.ranger.plugin.resourcematcher.RangerDefaultResourceMatcher",
+        "matcherOptions": {
+          "wildCard": true,
+          "ignoreCase": true
+        },
+        "validationRegEx": "",
+        "validationMessage": "",
+        "uiHint": "",
+        "label": "Schema Function",
+        "description": "Schema Function",
+        "accessTypeRestrictions": ["create", "drop", "show", "execute", "grant"]
       }
     ],
     "accessTypes": [


### PR DESCRIPTION
  Changes:                                                  
  - ranger-servicedef-trino.json — added execute and grant to accessTypeRestrictions for schemafunction (consistent with function and procedure)
  - trino-policies.json — added schemafunction resource definition to test serviceDef and alice-schemafunction test policy
  - RangerTrinoPluginTest.java — new test: verifies execute on schemafunction is allowed/denied based on policy, plus regression checks for procedure and function
