### PR TITLE
ADH-8311: Fix Kerberized Solr audit writes on Java 25

### DIFF
--- a/agents-audit/pom.xml
+++ b/agents-audit/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>ranger-plugins-audit</artifactId>

--- a/agents-audit/src/main/java/org/apache/ranger/audit/destination/SolrAuditDestination.java
+++ b/agents-audit/src/main/java/org/apache/ranger/audit/destination/SolrAuditDestination.java
@@ -188,6 +188,7 @@ public class SolrAuditDestination extends AuditDestination {
 									@Override
 									public CloudSolrClient run() throws Exception {
 										return new CloudSolrClient.Builder(zkhosts, Optional.empty())
+												.withParallelUpdates(false)
 												.withLBHttpSolrClientBuilder(new LBHttpSolrClient.Builder()
 														.withConnectionTimeout(1000)
 														.withHttpSolrClientBuilder(
@@ -207,7 +208,9 @@ public class SolrAuditDestination extends AuditDestination {
 								final CloudSolrClient solrCloudClient = MiscUtil.executePrivilegedAction(new PrivilegedExceptionAction<CloudSolrClient>() {
 									@Override
 									public CloudSolrClient run()  throws Exception {
-										CloudSolrClient solrCloudClient = new CloudSolrClient.Builder(zkhosts, Optional.empty()).build();
+										CloudSolrClient solrCloudClient = new CloudSolrClient.Builder(zkhosts, Optional.empty())
+												.withParallelUpdates(false)
+												.build();
 										return solrCloudClient;
 									};
 								});

--- a/agents-common/pom.xml
+++ b/agents-common/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>ranger-plugins-common</artifactId>

--- a/agents-cred/pom.xml
+++ b/agents-cred/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>ranger-plugins-cred</artifactId>

--- a/agents-installer/pom.xml
+++ b/agents-installer/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>ranger-plugins-installer</artifactId>

--- a/credentialbuilder/pom.xml
+++ b/credentialbuilder/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>credentialbuilder</artifactId>

--- a/dev-support/resource-mapping-manager/docker-compose-rmm-hdfs.yaml
+++ b/dev-support/resource-mapping-manager/docker-compose-rmm-hdfs.yaml
@@ -4,7 +4,7 @@ services:
       context: ../
       dockerfile: ./resource-mapping-manager/Dockerfile.resource-mapping-manager
       args:
-        - RANGER_VERSION=${RANGER_VERSION:-2.6.0.4-2.2.0-0}
+        - RANGER_VERSION=${RANGER_VERSION:-2.6.0.4-2.2.0-1}
         - RANGER_ADMIN_JAVA_VERSION=8
     depends_on:
       rmm-hive-server2:

--- a/dev-support/resource-mapping-manager/docker-compose-rmm-ozone.yaml
+++ b/dev-support/resource-mapping-manager/docker-compose-rmm-ozone.yaml
@@ -4,7 +4,7 @@ services:
       context: ../
       dockerfile: ./resource-mapping-manager/Dockerfile.resource-mapping-manager
       args:
-        - RANGER_VERSION=${RANGER_VERSION:-2.6.0.4-2.2.0-0}
+        - RANGER_VERSION=${RANGER_VERSION:-2.6.0.4-2.2.0-1}
         - RANGER_ADMIN_JAVA_VERSION=8
     depends_on:
       rmm-hive-server2:

--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -28,7 +28,7 @@
     <url>http://ranger.apache.org/</url>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.apache.ranger</groupId>
-    <version>2.6.0.4-2.2.0-0</version>
+    <version>2.6.0.4-2.2.0-1</version>
     <artifactId>ranger</artifactId>
     <packaging>pom</packaging>
     <licenses>

--- a/embeddedwebserver/pom.xml
+++ b/embeddedwebserver/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>embeddedwebserver</artifactId>

--- a/hbase-agent/pom.xml
+++ b/hbase-agent/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>ranger-hbase-plugin</artifactId>

--- a/hdfs-agent/pom.xml
+++ b/hdfs-agent/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>ranger-hdfs-plugin</artifactId>

--- a/hive-agent/pom.xml
+++ b/hive-agent/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>ranger-hive-plugin</artifactId>

--- a/intg/pom.xml
+++ b/intg/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/jisql/pom.xml
+++ b/jisql/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>jisql</artifactId>

--- a/kms/pom.xml
+++ b/kms/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
     </parent>
     <artifactId>ranger-kms</artifactId>
     <packaging>jar</packaging>

--- a/knox-agent/pom.xml
+++ b/knox-agent/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>ranger-knox-plugin</artifactId>

--- a/plugin-adscc/pom.xml
+++ b/plugin-adscc/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>ranger-adscc-plugin</artifactId>

--- a/plugin-atlas/pom.xml
+++ b/plugin-atlas/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>ranger-atlas-plugin</artifactId>

--- a/plugin-elasticsearch/pom.xml
+++ b/plugin-elasticsearch/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>ranger-elasticsearch-plugin</artifactId>

--- a/plugin-kafka/pom.xml
+++ b/plugin-kafka/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>ranger-kafka-plugin</artifactId>

--- a/plugin-kms/pom.xml
+++ b/plugin-kms/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>ranger-kms-plugin</artifactId>

--- a/plugin-kudu/pom.xml
+++ b/plugin-kudu/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>ranger-kudu-plugin</artifactId>

--- a/plugin-kylin/pom.xml
+++ b/plugin-kylin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>ranger-kylin-plugin</artifactId>

--- a/plugin-nestedstructure/pom.xml
+++ b/plugin-nestedstructure/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
     </parent>
 
     <artifactId>ranger-nestedstructure-plugin</artifactId>

--- a/plugin-nifi-registry/pom.xml
+++ b/plugin-nifi-registry/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>ranger-nifi-registry-plugin</artifactId>

--- a/plugin-nifi/pom.xml
+++ b/plugin-nifi/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>ranger-nifi-plugin</artifactId>

--- a/plugin-ozone/pom.xml
+++ b/plugin-ozone/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>ranger-ozone-plugin</artifactId>

--- a/plugin-presto/pom.xml
+++ b/plugin-presto/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>ranger-presto-plugin</artifactId>

--- a/plugin-schema-registry/pom.xml
+++ b/plugin-schema-registry/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>ranger-schema-registry-plugin</artifactId>

--- a/plugin-solr/pom.xml
+++ b/plugin-solr/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>ranger-solr-plugin</artifactId>

--- a/plugin-sqoop/pom.xml
+++ b/plugin-sqoop/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>ranger-sqoop-plugin</artifactId>

--- a/plugin-ssm/pom.xml
+++ b/plugin-ssm/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/plugin-trino/pom.xml
+++ b/plugin-trino/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/plugin-yarn/pom.xml
+++ b/plugin-yarn/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>ranger-yarn-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     </parent>
     <groupId>org.apache.ranger</groupId>
     <artifactId>ranger</artifactId>
-    <version>2.6.0.4-2.2.0-0</version>
+    <version>2.6.0.4-2.2.0-1</version>
     <packaging>pom</packaging>
     <name>ranger</name>
     <description>Security for Enforcing Enterprise Policies</description>

--- a/ranger-atlas-plugin-shim/pom.xml
+++ b/ranger-atlas-plugin-shim/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>ranger-atlas-plugin-shim</artifactId>

--- a/ranger-authn/pom.xml
+++ b/ranger-authn/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/ranger-common-ha/pom.xml
+++ b/ranger-common-ha/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>ranger-common-ha</artifactId>

--- a/ranger-elasticsearch-plugin-shim/pom.xml
+++ b/ranger-elasticsearch-plugin-shim/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>ranger-elasticsearch-plugin-shim</artifactId>

--- a/ranger-examples/conditions-enrichers/pom.xml
+++ b/ranger-examples/conditions-enrichers/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger-examples</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
     </parent>
     <artifactId>conditions-enrichers</artifactId>
     <name>Ranger Examples - Conditions and ContextEnrichers</name>

--- a/ranger-examples/distro/pom.xml
+++ b/ranger-examples/distro/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger-examples</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/ranger-examples/plugin-sampleapp/pom.xml
+++ b/ranger-examples/plugin-sampleapp/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger-examples</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
     </parent>
     <artifactId>ranger-sampleapp-plugin</artifactId>
     <packaging>jar</packaging>

--- a/ranger-examples/pom.xml
+++ b/ranger-examples/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
     </parent>
     <artifactId>ranger-examples</artifactId>
     <packaging>pom</packaging>

--- a/ranger-examples/sample-client/pom.xml
+++ b/ranger-examples/sample-client/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger-examples</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
     </parent>
 
     <artifactId>sample-client</artifactId>

--- a/ranger-examples/sampleapp/pom.xml
+++ b/ranger-examples/sampleapp/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger-examples</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
     </parent>
     <artifactId>sampleapp</artifactId>
     <packaging>jar</packaging>

--- a/ranger-hbase-plugin-shim/pom.xml
+++ b/ranger-hbase-plugin-shim/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>ranger-hbase-plugin-shim</artifactId>

--- a/ranger-hdfs-plugin-shim/pom.xml
+++ b/ranger-hdfs-plugin-shim/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>ranger-hdfs-plugin-shim</artifactId>

--- a/ranger-hive-chained-plugin-base/pom.xml
+++ b/ranger-hive-chained-plugin-base/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
     </parent>
 
     <artifactId>ranger-hive-chained-plugin-base</artifactId>

--- a/ranger-hive-chained-plugin-hdfs/pom.xml
+++ b/ranger-hive-chained-plugin-hdfs/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
     </parent>
 
     <artifactId>ranger-hive-chained-plugin-hdfs</artifactId>

--- a/ranger-hive-chained-plugin-ozone/pom.xml
+++ b/ranger-hive-chained-plugin-ozone/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
     </parent>
 
     <artifactId>ranger-hive-chained-plugin-ozone</artifactId>

--- a/ranger-hive-chained-plugin-trino/pom.xml
+++ b/ranger-hive-chained-plugin-trino/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
     </parent>
 
     <artifactId>ranger-hive-chained-plugin-trino</artifactId>

--- a/ranger-hive-plugin-shim/pom.xml
+++ b/ranger-hive-plugin-shim/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>ranger-hive-plugin-shim</artifactId>

--- a/ranger-kafka-plugin-shim/pom.xml
+++ b/ranger-kafka-plugin-shim/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>ranger-kafka-plugin-shim</artifactId>

--- a/ranger-kms-plugin-shim/pom.xml
+++ b/ranger-kms-plugin-shim/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>ranger-kms-plugin-shim</artifactId>

--- a/ranger-knox-plugin-shim/pom.xml
+++ b/ranger-knox-plugin-shim/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>ranger-knox-plugin-shim</artifactId>

--- a/ranger-kylin-plugin-shim/pom.xml
+++ b/ranger-kylin-plugin-shim/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>ranger-kylin-plugin-shim</artifactId>

--- a/ranger-metrics/pom.xml
+++ b/ranger-metrics/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/ranger-ozone-plugin-shim/pom.xml
+++ b/ranger-ozone-plugin-shim/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>ranger-ozone-plugin-shim</artifactId>

--- a/ranger-plugin-classloader/pom.xml
+++ b/ranger-plugin-classloader/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
     </parent>
     <artifactId>ranger-plugin-classloader</artifactId>
     <packaging>jar</packaging>

--- a/ranger-presto-plugin-shim/pom.xml
+++ b/ranger-presto-plugin-shim/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>ranger-presto-plugin-shim</artifactId>

--- a/ranger-solr-plugin-shim/pom.xml
+++ b/ranger-solr-plugin-shim/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>ranger-solr-plugin-shim</artifactId>

--- a/ranger-sqoop-plugin-shim/pom.xml
+++ b/ranger-sqoop-plugin-shim/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>ranger-sqoop-plugin-shim</artifactId>

--- a/ranger-storm-plugin-shim/pom.xml
+++ b/ranger-storm-plugin-shim/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>ranger-storm-plugin-shim</artifactId>

--- a/ranger-tools/pom.xml
+++ b/ranger-tools/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
     </parent>
     <artifactId>ranger-tools</artifactId>
     <packaging>jar</packaging>

--- a/ranger-trino-plugin-shim/pom.xml
+++ b/ranger-trino-plugin-shim/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/ranger-util/pom.xml
+++ b/ranger-util/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
     </parent>
     <artifactId>ranger-util</artifactId>
     <name>Ranger Util</name>

--- a/ranger-yarn-plugin-shim/pom.xml
+++ b/ranger-yarn-plugin-shim/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>ranger-yarn-plugin-shim</artifactId>

--- a/resource-mapping-manager/pom.xml
+++ b/resource-mapping-manager/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/security-admin/pom.xml
+++ b/security-admin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
     </parent>
     <artifactId>security-admin-web</artifactId>
     <packaging>war</packaging>

--- a/security-admin/src/main/java/org/apache/ranger/patch/cliutil/DbToSolrMigrationUtil.java
+++ b/security-admin/src/main/java/org/apache/ranger/patch/cliutil/DbToSolrMigrationUtil.java
@@ -412,7 +412,9 @@ public class DbToSolrMigrationUtil extends BaseLoader {
 				SolrHttpClientBuilder kb = krbBuild.getBuilder();
 				HttpClientUtil.setHttpClientBuilder(kb);
 				final List<String> zkhosts         = new ArrayList<String>(Arrays.asList(zkHosts.split(",")));
-				CloudSolrClient    solrCloudClient = new CloudSolrClient.Builder(zkhosts, null).build();
+				CloudSolrClient    solrCloudClient = new CloudSolrClient.Builder(zkhosts, null)
+						.withParallelUpdates(false)
+						.build();
 				solrCloudClient.setDefaultCollection(collectionName);
 				return solrCloudClient;
 			} catch (Exception e) {

--- a/storm-agent/pom.xml
+++ b/storm-agent/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>ranger-storm-plugin</artifactId>

--- a/tagsync/pom.xml
+++ b/tagsync/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
     </parent>
     <artifactId>ranger-tagsync</artifactId>
     <packaging>jar</packaging>

--- a/ugsync-util/pom.xml
+++ b/ugsync-util/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
     </parent>
     <artifactId>ugsync-util</artifactId>
     <packaging>jar</packaging>

--- a/ugsync/ldapconfigchecktool/ldapconfigcheck/pom.xml
+++ b/ugsync/ldapconfigchecktool/ldapconfigcheck/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <artifactId>ldapconfigcheck</artifactId>

--- a/ugsync/pom.xml
+++ b/ugsync/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>unixusersync</artifactId>

--- a/unixauthclient/pom.xml
+++ b/unixauthclient/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>unixauthclient</artifactId>

--- a/unixauthnative/pom.xml
+++ b/unixauthnative/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>credValidator</artifactId>

--- a/unixauthpam/pom.xml
+++ b/unixauthpam/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>pamCredValidator</artifactId>

--- a/unixauthservice/pom.xml
+++ b/unixauthservice/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.6.0.4-2.2.0-0</version>
+        <version>2.6.0.4-2.2.0-1</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>unixauthservice</artifactId>


### PR DESCRIPTION
Fix Kerberized Solr audit writes when Ranger runs with newer Java/Hadoop runtimes.

With Java 25 and Hadoop 3.4.3, `SubjectUtil.doAs()` uses the newer `Subject.callAs()` path. The authenticated `Subject` is scoped to the current execution context and is not reliably available in SolrJ worker threads created by `CloudSolrClient` parallel updates.

This caused Ranger audit writes to fail against Kerberized Solr with `401 Unauthorized` / `No valid credentials provided`, even though the keytab login itself succeeded.

## Changes

- Disable SolrJ parallel update execution for `CloudSolrClient` in `SolrAuditDestination`.
- Apply the same behavior to `DbToSolrMigrationUtil` for audit migration writes to SolrCloud.

## Why

Ranger wraps `solrClient.add(...)` in a Kerberos action, but SolrJ parallel updates can move the actual HTTP/SPNEGO update request to an internal executor thread. On modern Java/Hadoop, that thread does not inherit the `Subject` from the caller context.

Using `withParallelUpdates(false)` keeps the Solr update request inside the active Kerberos action context.
