### PR TITLE
ADH-8486: fix Spark Ranger stale policy cache bypass

### DIFF
--- a/agents-audit/src/main/java/org/apache/ranger/audit/queue/AuditFileCacheProviderSpool.java
+++ b/agents-audit/src/main/java/org/apache/ranger/audit/queue/AuditFileCacheProviderSpool.java
@@ -149,6 +149,13 @@ public class AuditFileCacheProviderSpool implements Runnable {
                     "755");
             filePermissions = AuditFileUtil.parsePermissions(spoolFilePerms);
             Set<PosixFilePermission> dirPermissions = AuditFileUtil.parsePermissions(spoolDirPerms);
+            AuditFileUtil.ResolvedDirectory resolvedLogDirectory = AuditFileUtil.resolveDirectory(logFolderProp,
+                    MiscUtil.getStringProperty(props, propPrefix + ".subdir.mode"),
+                    dirPermissions,
+                    filePermissions);
+            logFolderProp = resolvedLogDirectory.getPath();
+            dirPermissions = resolvedLogDirectory.getDirPermissions();
+            filePermissions = resolvedLogDirectory.getFilePermissions();
             logFileNameFormat = MiscUtil.getStringProperty(props,
                     basePropertyName + "." + PROP_FILE_SPOOL_LOCAL_FILE_NAME);
             String archiveFolderProp = MiscUtil.getStringProperty(props,
@@ -180,12 +187,11 @@ public class AuditFileCacheProviderSpool implements Runnable {
                 return false;
             }
             logFolder = new File(logFolderProp);
-            if (!logFolder.isDirectory()) {
-                AuditFileUtil.createDirectoryWithPermissions(logFolder, dirPermissions);
-                if (!logFolder.isDirectory()) {
-                    logger.error("File Spool folder not found and can't be created. folder={}, queueName={}", logFolder.getAbsolutePath(),  FILE_CACHE_PROVIDER_NAME);
-                    return false;
-                }
+            try {
+                resolvedLogDirectory.ensureDirectory();
+            } catch (Exception excp) {
+                logger.error("File Spool folder not found, unsafe, or can't be created. folder={}, queueName={}", logFolder.getAbsolutePath(),  FILE_CACHE_PROVIDER_NAME, excp);
+                return false;
             }
             logger.info("logFolder=" + logFolder + ", queueName="
                     + FILE_CACHE_PROVIDER_NAME);

--- a/agents-audit/src/main/java/org/apache/ranger/audit/queue/AuditFileCacheProviderSpool.java
+++ b/agents-audit/src/main/java/org/apache/ranger/audit/queue/AuditFileCacheProviderSpool.java
@@ -71,6 +71,7 @@ public class AuditFileCacheProviderSpool implements Runnable {
     public static final String PROP_FILE_SPOOL_INDEX_FILE 				= "filespool.index.filename";
     public static final String PROP_FILE_SPOOL_DEST_RETRY_MS 			= "filespool.destination.retry.ms";
     public static final String PROP_FILE_SPOOL_BATCH_SIZE               = "filespool.buffer.size";
+    public static final String PROP_FILE_SPOOL_SUBDIR_MODE              = "filespool.subdir.mode";
 
     public static final String AUDIT_IS_FILE_CACHE_PROVIDER_ENABLE_PROP = "xasecure.audit.provider.filecache.is.enabled";
     public static final String FILE_CACHE_PROVIDER_NAME 				= "AuditFileCacheProviderSpool";
@@ -114,6 +115,7 @@ public class AuditFileCacheProviderSpool implements Runnable {
     boolean isSpoolingSuccessful = true;
 
     Set<PosixFilePermission> filePermissions = AuditFileUtil.parsePermissions("644");
+    AuditFileUtil.ResolvedDirectory resolvedLogDirectory = null;
 
     public AuditFileCacheProviderSpool(AuditHandler consumerProvider) {
         this.consumerProvider = consumerProvider;
@@ -149,8 +151,8 @@ public class AuditFileCacheProviderSpool implements Runnable {
                     "755");
             filePermissions = AuditFileUtil.parsePermissions(spoolFilePerms);
             Set<PosixFilePermission> dirPermissions = AuditFileUtil.parsePermissions(spoolDirPerms);
-            AuditFileUtil.ResolvedDirectory resolvedLogDirectory = AuditFileUtil.resolveDirectory(logFolderProp,
-                    MiscUtil.getStringProperty(props, propPrefix + ".subdir.mode"),
+            resolvedLogDirectory = AuditFileUtil.resolveDirectory(logFolderProp,
+                    MiscUtil.getStringProperty(props, propPrefix + "." + PROP_FILE_SPOOL_SUBDIR_MODE),
                     dirPermissions,
                     filePermissions);
             logFolderProp = resolvedLogDirectory.getPath();
@@ -208,12 +210,11 @@ public class AuditFileCacheProviderSpool implements Runnable {
             } else {
                 archiveFolder = new File(archiveFolderProp);
             }
-            if (!archiveFolder.isDirectory()) {
-                AuditFileUtil.createDirectoryWithPermissions(archiveFolder, dirPermissions);
-                if (!archiveFolder.isDirectory()) {
-                    logger.error("File Spool archive folder not found and can't be created. folder={}, queueName={}", archiveFolder.getAbsolutePath(), FILE_CACHE_PROVIDER_NAME);
-                    return false;
-                }
+            try {
+                resolvedLogDirectory.ensureChildDirectory(archiveFolder);
+            } catch (Exception excp) {
+                logger.error("File Spool archive folder not found, unsafe, or can't be created. folder={}, queueName={}", archiveFolder.getAbsolutePath(), FILE_CACHE_PROVIDER_NAME, excp);
+                return false;
             }
             logger.info("archiveFolder=" + archiveFolder + ", queueName="
                     + FILE_CACHE_PROVIDER_NAME);
@@ -237,8 +238,8 @@ public class AuditFileCacheProviderSpool implements Runnable {
                             + indexFile.getPath());
                     return false;
                 }
-                AuditFileUtil.setPermissions(indexFile, filePermissions);
             }
+            resolvedLogDirectory.secureFile(indexFile);
             logger.info("indexFile=" + indexFile + ", queueName="
                     + FILE_CACHE_PROVIDER_NAME);
 
@@ -256,8 +257,8 @@ public class AuditFileCacheProviderSpool implements Runnable {
                             + indexDoneFile.getPath());
                     return false;
                 }
-                AuditFileUtil.setPermissions(indexDoneFile, filePermissions);
             }
+            resolvedLogDirectory.secureFile(indexDoneFile);
             logger.info("indexDoneFile=" + indexDoneFile + ", queueName="
                     + FILE_CACHE_PROVIDER_NAME);
 
@@ -525,7 +526,7 @@ public class AuditFileCacheProviderSpool implements Runnable {
             boolean created = outLogFile.createNewFile();
             if (created)
                 try {
-                    AuditFileUtil.setPermissions(outLogFile, filePermissions);
+                    resolvedLogDirectory.secureFile(outLogFile);
                 } catch (Exception e) {
                     logger.debug("Failed to set permissions on {}", outLogFile, e);
                 }
@@ -665,6 +666,7 @@ public class AuditFileCacheProviderSpool implements Runnable {
             out.println(MiscUtil.stringify(auditIndexRecord));
         }
         out.close();
+        resolvedLogDirectory.secureFile(indexFile);
         // printIndex();
 
     }
@@ -680,6 +682,7 @@ public class AuditFileCacheProviderSpool implements Runnable {
         out.println(line);
         out.flush();
         out.close();
+        resolvedLogDirectory.secureFile(indexDoneFile);
 
         // After Each file is read and audit events are pushed into pipe, we flush to reach the destination immediate.
         consumerProvider.flush();

--- a/agents-audit/src/main/java/org/apache/ranger/audit/queue/AuditFileQueueSpool.java
+++ b/agents-audit/src/main/java/org/apache/ranger/audit/queue/AuditFileQueueSpool.java
@@ -146,6 +146,13 @@ public class AuditFileQueueSpool implements Runnable {
                     "755");
             filePermissions = AuditFileUtil.parsePermissions(spoolFilePerms);
             Set<PosixFilePermission> dirPermissions = AuditFileUtil.parsePermissions(spoolDirPerms);
+            AuditFileUtil.ResolvedDirectory resolvedLogDirectory = AuditFileUtil.resolveDirectory(logFolderProp,
+                    MiscUtil.getStringProperty(props, propPrefix + ".subdir.mode"),
+                    dirPermissions,
+                    filePermissions);
+            logFolderProp = resolvedLogDirectory.getPath();
+            dirPermissions = resolvedLogDirectory.getDirPermissions();
+            filePermissions = resolvedLogDirectory.getFilePermissions();
             logFileNameFormat = MiscUtil.getStringProperty(props,
                     basePropertyName + "." + PROP_FILE_SPOOL_LOCAL_FILE_NAME);
             String archiveFolderProp = MiscUtil.getStringProperty(props,
@@ -176,12 +183,11 @@ public class AuditFileQueueSpool implements Runnable {
                 return false;
             }
             logFolder = new File(logFolderProp);
-            if (!logFolder.isDirectory()) {
-                AuditFileUtil.createDirectoryWithPermissions(logFolder, dirPermissions);
-                if (!logFolder.isDirectory()) {
-                    logger.error("File Spool folder not found and can't be created. folder={}, queueName={}", logFolder.getAbsolutePath(),  FILE_QUEUE_PROVIDER_NAME);
-                    return false;
-                }
+            try {
+                resolvedLogDirectory.ensureDirectory();
+            } catch (Exception excp) {
+                logger.error("File Spool folder not found, unsafe, or can't be created. folder={}, queueName={}", logFolder.getAbsolutePath(),  FILE_QUEUE_PROVIDER_NAME, excp);
+                return false;
             }
             logger.info("logFolder=" + logFolder + ", queueName="
                     + FILE_QUEUE_PROVIDER_NAME);

--- a/agents-audit/src/main/java/org/apache/ranger/audit/queue/AuditFileQueueSpool.java
+++ b/agents-audit/src/main/java/org/apache/ranger/audit/queue/AuditFileQueueSpool.java
@@ -69,6 +69,7 @@ public class AuditFileQueueSpool implements Runnable {
     public static final String PROP_FILE_SPOOL_INDEX_FILE 			   = "filespool.index.filename";
     public static final String PROP_FILE_SPOOL_DEST_RETRY_MS 		   = "filespool.destination.retry.ms";
     public static final String PROP_FILE_SPOOL_BATCH_SIZE              = "filespool.buffer.size";
+    public static final String PROP_FILE_SPOOL_SUBDIR_MODE             = "filespool.subdir.mode";
     public static final String FILE_QUEUE_PROVIDER_NAME 			   = "AuditFileQueueSpool";
     public static final String DEFAULT_AUDIT_FILE_TYPE                 = "json";
 
@@ -111,6 +112,7 @@ public class AuditFileQueueSpool implements Runnable {
     boolean isSpoolingSuccessful = true;
 
     Set<PosixFilePermission> filePermissions = AuditFileUtil.parsePermissions("644");
+    AuditFileUtil.ResolvedDirectory resolvedLogDirectory = null;
 
     public AuditFileQueueSpool(AuditHandler consumerProvider) {
         this.consumerProvider = consumerProvider;
@@ -146,8 +148,8 @@ public class AuditFileQueueSpool implements Runnable {
                     "755");
             filePermissions = AuditFileUtil.parsePermissions(spoolFilePerms);
             Set<PosixFilePermission> dirPermissions = AuditFileUtil.parsePermissions(spoolDirPerms);
-            AuditFileUtil.ResolvedDirectory resolvedLogDirectory = AuditFileUtil.resolveDirectory(logFolderProp,
-                    MiscUtil.getStringProperty(props, propPrefix + ".subdir.mode"),
+            resolvedLogDirectory = AuditFileUtil.resolveDirectory(logFolderProp,
+                    MiscUtil.getStringProperty(props, propPrefix + "." + PROP_FILE_SPOOL_SUBDIR_MODE),
                     dirPermissions,
                     filePermissions);
             logFolderProp = resolvedLogDirectory.getPath();
@@ -204,12 +206,11 @@ public class AuditFileQueueSpool implements Runnable {
             } else {
                 archiveFolder = new File(archiveFolderProp);
             }
-            if (!archiveFolder.isDirectory()) {
-                AuditFileUtil.createDirectoryWithPermissions(archiveFolder, dirPermissions);
-                if (!archiveFolder.isDirectory()) {
-                    logger.error("File Spool archive folder not found and can't be created. folder={}, queueName={}", archiveFolder.getAbsolutePath(), FILE_QUEUE_PROVIDER_NAME);
-                    return false;
-                }
+            try {
+                resolvedLogDirectory.ensureChildDirectory(archiveFolder);
+            } catch (Exception excp) {
+                logger.error("File Spool archive folder not found, unsafe, or can't be created. folder={}, queueName={}", archiveFolder.getAbsolutePath(), FILE_QUEUE_PROVIDER_NAME, excp);
+                return false;
             }
             logger.info("archiveFolder=" + archiveFolder + ", queueName="
                     + FILE_QUEUE_PROVIDER_NAME);
@@ -233,8 +234,8 @@ public class AuditFileQueueSpool implements Runnable {
                             + indexFile.getPath());
                     return false;
                 }
-                AuditFileUtil.setPermissions(indexFile, filePermissions);
             }
+            resolvedLogDirectory.secureFile(indexFile);
             logger.info("indexFile=" + indexFile + ", queueName="
                     + FILE_QUEUE_PROVIDER_NAME);
 
@@ -252,8 +253,8 @@ public class AuditFileQueueSpool implements Runnable {
                             + indexDoneFile.getPath());
                     return false;
                 }
-                AuditFileUtil.setPermissions(indexDoneFile, filePermissions);
             }
+            resolvedLogDirectory.secureFile(indexDoneFile);
             logger.info("indexDoneFile=" + indexDoneFile + ", queueName="
                     + FILE_QUEUE_PROVIDER_NAME);
 
@@ -526,7 +527,7 @@ public class AuditFileQueueSpool implements Runnable {
             boolean created = outLogFile.createNewFile();
             if (created)
                 try {
-                    AuditFileUtil.setPermissions(outLogFile, filePermissions);
+                    resolvedLogDirectory.secureFile(outLogFile);
                 } catch (Exception e) {
                     logger.debug("Failed to set permissions on {}", outLogFile, e);
                 }
@@ -666,6 +667,7 @@ public class AuditFileQueueSpool implements Runnable {
                 out.println(MiscUtil.stringify(auditIndexRecord));
             }
         }
+        resolvedLogDirectory.secureFile(indexFile);
     }
 
     void appendToDoneFile(AuditIndexRecord indexRecord)
@@ -679,6 +681,7 @@ public class AuditFileQueueSpool implements Runnable {
         out.println(line);
         out.flush();
         out.close();
+        resolvedLogDirectory.secureFile(indexDoneFile);
 
         // After Each file is read and audit events are pushed into pipe, we flush to reach the destination immediate.
         consumerProvider.flush();

--- a/agents-audit/src/main/java/org/apache/ranger/audit/queue/AuditFileSpool.java
+++ b/agents-audit/src/main/java/org/apache/ranger/audit/queue/AuditFileSpool.java
@@ -62,6 +62,7 @@ public class AuditFileSpool implements Runnable {
 	public static final String PROP_FILE_SPOOL_FILE_ROLLOVER = "filespool.file.rollover.sec";
 	public static final String PROP_FILE_SPOOL_INDEX_FILE = "filespool.index.filename";
 	public static final String PROP_FILE_SPOOL_DEST_RETRY_MS = "filespool.destination.retry.ms";
+	public static final String PROP_FILE_SPOOL_SUBDIR_MODE = "filespool.subdir.mode";
 	public static final String CONSUMER = ", consumer=";
 
 	AuditQueue queueProvider = null;
@@ -104,6 +105,7 @@ public class AuditFileSpool implements Runnable {
 	boolean isDestDown = false;
 
 	Set<PosixFilePermission> filePermissions = AuditFileUtil.parsePermissions("644");
+	AuditFileUtil.ResolvedDirectory resolvedLogDirectory = null;
 
 	public AuditFileSpool(AuditQueue queueProvider,
 			AuditHandler consumerProvider) {
@@ -137,8 +139,8 @@ public class AuditFileSpool implements Runnable {
 					"755");
 			filePermissions = AuditFileUtil.parsePermissions(spoolFilePerms);
 			Set<PosixFilePermission> dirPermissions = AuditFileUtil.parsePermissions(spoolDirPerms);
-			AuditFileUtil.ResolvedDirectory resolvedLogDirectory = AuditFileUtil.resolveDirectory(logFolderProp,
-					MiscUtil.getStringProperty(props, propPrefix + ".subdir.mode"),
+			resolvedLogDirectory = AuditFileUtil.resolveDirectory(logFolderProp,
+					MiscUtil.getStringProperty(props, propPrefix + "." + PROP_FILE_SPOOL_SUBDIR_MODE),
 					dirPermissions,
 					filePermissions);
 			logFolderProp = resolvedLogDirectory.getPath();
@@ -187,12 +189,11 @@ public class AuditFileSpool implements Runnable {
 			} else {
 				archiveFolder = new File(archiveFolderProp);
 			}
-			if (!archiveFolder.isDirectory()) {
-				AuditFileUtil.createDirectoryWithPermissions(archiveFolder, dirPermissions);
-				if (!archiveFolder.isDirectory()) {
-					logger.error("File Spool archive folder not found and can't be created. folder={}, queueName={}", archiveFolder.getAbsolutePath(), queueProvider.getName());
-					return false;
-				}
+			try {
+				resolvedLogDirectory.ensureChildDirectory(archiveFolder);
+			} catch (Exception excp) {
+				logger.error("File Spool archive folder not found, unsafe, or can't be created. folder={}, queueName={}", archiveFolder.getAbsolutePath(), queueProvider.getName(), excp);
+				return false;
 			}
 			logger.info("archiveFolder={}, queueName={}", archiveFolder, queueProvider.getName());
 
@@ -214,8 +215,8 @@ public class AuditFileSpool implements Runnable {
 					logger.error("Error creating index file. fileName={}", indexDoneFile.getPath());
 					return false;
 				}
-				AuditFileUtil.setPermissions(indexFile, filePermissions);
 			}
+			resolvedLogDirectory.secureFile(indexFile);
 			logger.info("indexFile={}, queueName={}", indexFile, queueProvider.getName());
 
 			int lastDot = indexFileName.lastIndexOf('.');
@@ -231,8 +232,8 @@ public class AuditFileSpool implements Runnable {
 					logger.error("Error creating index done file. fileName={}", indexDoneFile.getPath());
 					return false;
 				}
-				AuditFileUtil.setPermissions(indexDoneFile, filePermissions);
 			}
+			resolvedLogDirectory.secureFile(indexDoneFile);
 			logger.info("indexDoneFile={}, queueName={}", indexDoneFile, queueProvider.getName());
 
 			// Load index file
@@ -470,7 +471,7 @@ public class AuditFileSpool implements Runnable {
 			boolean created = outLogFile.createNewFile();
 			if (created)
 				try {
-					AuditFileUtil.setPermissions(outLogFile, filePermissions);
+					resolvedLogDirectory.secureFile(outLogFile);
 				} catch (Exception e) {
 					logger.debug("Failed to set permissions on {}", outLogFile, e);
 				}
@@ -589,6 +590,7 @@ public class AuditFileSpool implements Runnable {
 				out.println(MiscUtil.stringify(auditIndexRecord));
 			}
 		}
+		resolvedLogDirectory.secureFile(indexFile);
 	}
 
 	void appendToDoneFile(AuditIndexRecord indexRecord)
@@ -600,6 +602,7 @@ public class AuditFileSpool implements Runnable {
 		out.println(line);
 		out.flush();
 		out.close();
+		resolvedLogDirectory.secureFile(indexDoneFile);
 
 		// Move to archive folder
 		File logFile = null;

--- a/agents-audit/src/main/java/org/apache/ranger/audit/queue/AuditFileSpool.java
+++ b/agents-audit/src/main/java/org/apache/ranger/audit/queue/AuditFileSpool.java
@@ -137,6 +137,13 @@ public class AuditFileSpool implements Runnable {
 					"755");
 			filePermissions = AuditFileUtil.parsePermissions(spoolFilePerms);
 			Set<PosixFilePermission> dirPermissions = AuditFileUtil.parsePermissions(spoolDirPerms);
+			AuditFileUtil.ResolvedDirectory resolvedLogDirectory = AuditFileUtil.resolveDirectory(logFolderProp,
+					MiscUtil.getStringProperty(props, propPrefix + ".subdir.mode"),
+					dirPermissions,
+					filePermissions);
+			logFolderProp = resolvedLogDirectory.getPath();
+			dirPermissions = resolvedLogDirectory.getDirPermissions();
+			filePermissions = resolvedLogDirectory.getFilePermissions();
 			logFileNameFormat = MiscUtil.getStringProperty(props,
 					basePropertyName + "." + PROP_FILE_SPOOL_LOCAL_FILE_NAME);
 			String archiveFolderProp = MiscUtil.getStringProperty(props,
@@ -161,12 +168,11 @@ public class AuditFileSpool implements Runnable {
 				return false;
 			}
 			logFolder = new File(logFolderProp);
-			if (!logFolder.isDirectory()) {
-				AuditFileUtil.createDirectoryWithPermissions(logFolder, dirPermissions);
-				if (!logFolder.isDirectory()) {
-					logger.error("File Spool folder not found and can't be created. folder={}, queueName={}", logFolder.getAbsolutePath(),  queueProvider.getName());
-					return false;
-				}
+			try {
+				resolvedLogDirectory.ensureDirectory();
+			} catch (Exception excp) {
+				logger.error("File Spool folder not found, unsafe, or can't be created. folder={}, queueName={}", logFolder.getAbsolutePath(),  queueProvider.getName(), excp);
+				return false;
 			}
 			logger.info("logFolder={}, queueName={}", logFolder, queueProvider.getName());
 

--- a/agents-audit/src/main/java/org/apache/ranger/audit/utils/AuditFileUtil.java
+++ b/agents-audit/src/main/java/org/apache/ranger/audit/utils/AuditFileUtil.java
@@ -28,6 +28,9 @@ import java.nio.file.attribute.PosixFilePermissions;
 import java.util.Set;
 
 public class AuditFileUtil {
+    public static final String SUBDIR_MODE_DISABLED = "disabled";
+    public static final String SUBDIR_MODE_PERUSER  = "peruser";
+    public static final String SUBDIR_MODE_PERGROUP = "pergroup";
 
     public static void setPermissions(File file, Set<PosixFilePermission> perms) throws IOException {
         Path path = file.toPath();
@@ -54,6 +57,34 @@ public class AuditFileUtil {
         Path path = dir.toPath();
         Files.createDirectories(path, attr);
         Files.setPosixFilePermissions(path, perms);
+    }
+
+    public static ResolvedDirectory resolveDirectory(String baseDir, String subdirMode, Set<PosixFilePermission> defaultDirPerms, Set<PosixFilePermission> defaultFilePerms) {
+        return new ResolvedDirectory(LocalDirectoryResolver.resolveAuditSpool(baseDir, subdirMode, defaultDirPerms, defaultFilePerms));
+    }
+
+    public static final class ResolvedDirectory {
+        private final LocalDirectoryResolver.ResolvedDirectory delegate;
+
+        private ResolvedDirectory(LocalDirectoryResolver.ResolvedDirectory delegate) {
+            this.delegate = delegate;
+        }
+
+        public String getPath() {
+            return delegate.getPath();
+        }
+
+        public Set<PosixFilePermission> getDirPermissions() {
+            return delegate.getDirPermissions();
+        }
+
+        public Set<PosixFilePermission> getFilePermissions() {
+            return delegate.getFilePermissions();
+        }
+
+        public void ensureDirectory() throws IOException {
+            delegate.ensureDirectory();
+        }
     }
 
 }

--- a/agents-audit/src/main/java/org/apache/ranger/audit/utils/AuditFileUtil.java
+++ b/agents-audit/src/main/java/org/apache/ranger/audit/utils/AuditFileUtil.java
@@ -35,7 +35,7 @@ public class AuditFileUtil {
     public static void setPermissions(File file, Set<PosixFilePermission> perms) throws IOException {
         Path path = file.toPath();
         Files.setPosixFilePermissions(path, perms);
-        }
+    }
 
     public static Set<PosixFilePermission> parsePermissions(String permStr) {
         if (StringUtils.length(permStr) != 3) {
@@ -84,6 +84,14 @@ public class AuditFileUtil {
 
         public void ensureDirectory() throws IOException {
             delegate.ensureDirectory();
+        }
+
+        public void ensureChildDirectory(File directory) throws IOException {
+            delegate.ensureChildDirectory(directory);
+        }
+
+        public void secureFile(File file) throws IOException {
+            delegate.secureFile(file);
         }
     }
 

--- a/agents-audit/src/main/java/org/apache/ranger/audit/utils/LocalDirectoryResolver.java
+++ b/agents-audit/src/main/java/org/apache/ranger/audit/utils/LocalDirectoryResolver.java
@@ -21,6 +21,7 @@ import org.apache.hadoop.security.UserGroupInformation;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
@@ -40,6 +41,8 @@ public final class LocalDirectoryResolver {
     private static final Set<PosixFilePermission> PERUSER_FILE_PERMS  = PosixFilePermissions.fromString("rw-------");
     private static final Set<PosixFilePermission> PERGROUP_DIR_PERMS  = PosixFilePermissions.fromString("rwxrwx---");
     private static final Set<PosixFilePermission> PERGROUP_FILE_PERMS = PosixFilePermissions.fromString("rw-rw----");
+    private static final int DIRECTORY_VALIDATION_RETRY_COUNT = 3;
+    private static final long DIRECTORY_VALIDATION_RETRY_INTERVAL_MS = 50L;
 
     private LocalDirectoryResolver() {
     }
@@ -164,15 +167,27 @@ public final class LocalDirectoryResolver {
                 ensureBaseDirectory();
             }
 
+            boolean createdByAnotherProcess = false;
+
             if (Files.exists(directory, LinkOption.NOFOLLOW_LINKS)) {
                 validateDirectory(directory, dirPermissions, expectedOwner, expectedGroup, directoryLabel, ownershipLabel);
+                return;
             } else if (StringUtils.isNotBlank(basePath)) {
-                Files.createDirectory(directory, PosixFilePermissions.asFileAttribute(dirPermissions));
-                Files.setPosixFilePermissions(directory, dirPermissions);
-                validateDirectory(directory, dirPermissions, expectedOwner, expectedGroup, directoryLabel, ownershipLabel);
-            } else {
+                try {
+                    Files.createDirectory(directory, PosixFilePermissions.asFileAttribute(dirPermissions));
+                    Files.setPosixFilePermissions(directory, dirPermissions);
+                } catch (FileAlreadyExistsException ignored) {
+                    // Another local process can create the same per-user/per-group subdirectory concurrently.
+                    createdByAnotherProcess = true;
+                }
+            } else if (!Files.exists(directory, LinkOption.NOFOLLOW_LINKS)) {
                 Files.createDirectories(directory, PosixFilePermissions.asFileAttribute(dirPermissions));
                 Files.setPosixFilePermissions(directory, dirPermissions);
+            }
+
+            if (createdByAnotherProcess) {
+                validateDirectoryAfterConcurrentCreate(directory, dirPermissions, expectedOwner, expectedGroup, directoryLabel, ownershipLabel);
+            } else {
                 validateDirectory(directory, dirPermissions, expectedOwner, expectedGroup, directoryLabel, ownershipLabel);
             }
         }
@@ -209,6 +224,31 @@ public final class LocalDirectoryResolver {
                     throw new IOException("Unexpected group on " + ownershipLabel + " " + directory + ": expected " + expectedGroup + ", actual " + attrs.group().getName());
                 }
             }
+        }
+
+        private void validateDirectoryAfterConcurrentCreate(Path directory, Set<PosixFilePermission> expectedPermissions, String expectedOwner, String expectedGroup, String label, String ownershipLabel) throws IOException {
+            IOException lastException = null;
+
+            for (int attempt = 0; attempt < DIRECTORY_VALIDATION_RETRY_COUNT; attempt++) {
+                try {
+                    validateDirectory(directory, expectedPermissions, expectedOwner, expectedGroup, label, ownershipLabel);
+                    return;
+                } catch (IOException exception) {
+                    lastException = exception;
+
+                    if (attempt + 1 < DIRECTORY_VALIDATION_RETRY_COUNT) {
+                        try {
+                            Thread.sleep(DIRECTORY_VALIDATION_RETRY_INTERVAL_MS);
+                        } catch (InterruptedException interruptedException) {
+                            Thread.currentThread().interrupt();
+                            exception.addSuppressed(interruptedException);
+                            throw exception;
+                        }
+                    }
+                }
+            }
+
+            throw lastException;
         }
     }
 }

--- a/agents-audit/src/main/java/org/apache/ranger/audit/utils/LocalDirectoryResolver.java
+++ b/agents-audit/src/main/java/org/apache/ranger/audit/utils/LocalDirectoryResolver.java
@@ -26,6 +26,7 @@ import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.attribute.GroupPrincipal;
 import java.nio.file.attribute.PosixFileAttributeView;
 import java.nio.file.attribute.PosixFileAttributes;
 import java.nio.file.attribute.PosixFilePermission;
@@ -62,8 +63,9 @@ public final class LocalDirectoryResolver {
             return new ResolvedDirectory(null, baseDir, null, defaultDirPerms, defaultFilePerms, null, null, directoryLabel, baseDirectoryLabel, ownershipLabel);
         } else if (SUBDIR_MODE_PERUSER.equals(mode)) {
             String user = sanitizePathElement(getCurrentUser(), "user", subdirDescription);
+            String owner = getCurrentProcessUser(subdirDescription);
 
-            return new ResolvedDirectory(baseDir, appendPath(baseDir, user), defaultDirPerms, PERUSER_DIR_PERMS, PERUSER_FILE_PERMS, user, null, directoryLabel, baseDirectoryLabel, ownershipLabel);
+            return new ResolvedDirectory(baseDir, appendPath(baseDir, user), defaultDirPerms, PERUSER_DIR_PERMS, PERUSER_FILE_PERMS, owner, null, directoryLabel, baseDirectoryLabel, ownershipLabel);
         } else if (SUBDIR_MODE_PERGROUP.equals(mode)) {
             String group = sanitizePathElement(getCurrentGroup(subdirDescription), "group", subdirDescription);
 
@@ -110,6 +112,16 @@ public final class LocalDirectoryResolver {
         try {
             UserGroupInformation ugi = UserGroupInformation.getCurrentUser();
 
+            if (ugi != null && ugi.getGroupNames() != null) {
+                String shortUserName = ugi.getShortUserName();
+
+                for (String groupName : ugi.getGroupNames()) {
+                    if (StringUtils.isNotBlank(groupName) && !StringUtils.equals(groupName, shortUserName)) {
+                        return groupName;
+                    }
+                }
+            }
+
             if (ugi != null && StringUtils.isNotBlank(ugi.getPrimaryGroupName())) {
                 return ugi.getPrimaryGroupName();
             }
@@ -117,6 +129,16 @@ public final class LocalDirectoryResolver {
         }
 
         throw new IllegalStateException("Unable to determine current user's primary group for " + subdirDescription + " subdir");
+    }
+
+    private static String getCurrentProcessUser(String subdirDescription) {
+        String ret = StringUtils.trim(System.getProperty("user.name"));
+
+        if (StringUtils.isBlank(ret)) {
+            throw new IllegalStateException("Unable to determine current process user for " + subdirDescription + " subdir");
+        }
+
+        return ret;
     }
 
     public static final class ResolvedDirectory {
@@ -170,11 +192,12 @@ public final class LocalDirectoryResolver {
             boolean createdByAnotherProcess = false;
 
             if (Files.exists(directory, LinkOption.NOFOLLOW_LINKS)) {
-                validateDirectory(directory, dirPermissions, expectedOwner, expectedGroup, directoryLabel, ownershipLabel);
+                validateDirectoryAfterConcurrentCreate(directory, dirPermissions, expectedOwner, expectedGroup, directoryLabel, ownershipLabel);
                 return;
             } else if (StringUtils.isNotBlank(basePath)) {
                 try {
                     Files.createDirectory(directory, PosixFilePermissions.asFileAttribute(dirPermissions));
+                    setGroupOwner(directory, expectedGroup);
                     Files.setPosixFilePermissions(directory, dirPermissions);
                 } catch (FileAlreadyExistsException ignored) {
                     // Another local process can create the same per-user/per-group subdirectory concurrently.
@@ -182,6 +205,7 @@ public final class LocalDirectoryResolver {
                 }
             } else if (!Files.exists(directory, LinkOption.NOFOLLOW_LINKS)) {
                 Files.createDirectories(directory, PosixFilePermissions.asFileAttribute(dirPermissions));
+                setGroupOwner(directory, expectedGroup);
                 Files.setPosixFilePermissions(directory, dirPermissions);
             }
 
@@ -192,6 +216,39 @@ public final class LocalDirectoryResolver {
             }
         }
 
+        public void ensureChildDirectory(File directory) throws IOException {
+            if (directory == null) {
+                return;
+            }
+
+            Path childDirectory = directory.toPath();
+
+            if (!Files.exists(childDirectory, LinkOption.NOFOLLOW_LINKS)) {
+                try {
+                    Files.createDirectories(childDirectory, PosixFilePermissions.asFileAttribute(dirPermissions));
+                } catch (FileAlreadyExistsException ignored) {
+                    // Another local process can create the same child directory concurrently.
+                }
+            }
+
+            setGroupOwner(childDirectory, expectedGroup);
+            Files.setPosixFilePermissions(childDirectory, dirPermissions);
+            validateDirectoryAfterConcurrentCreate(childDirectory, dirPermissions, expectedOwner, expectedGroup, directoryLabel, ownershipLabel);
+        }
+
+        public void secureFile(File file) throws IOException {
+            if (file == null) {
+                return;
+            }
+
+            Path secureFile = file.toPath();
+
+            validateFile(secureFile, null, null, null, "File", ownershipLabel);
+            setGroupOwner(secureFile, expectedGroup);
+            Files.setPosixFilePermissions(secureFile, filePermissions);
+            validateFile(secureFile, filePermissions, expectedOwner, expectedGroup, "File", ownershipLabel);
+        }
+
         private void ensureBaseDirectory() throws IOException {
             Path baseDirectory = Paths.get(basePath);
 
@@ -200,6 +257,20 @@ public final class LocalDirectoryResolver {
             }
 
             validateDirectory(baseDirectory, baseDirPermissions, null, null, baseDirectoryLabel, ownershipLabel);
+        }
+
+        private void setGroupOwner(Path path, String expectedGroup) throws IOException {
+            if (StringUtils.isBlank(expectedGroup)) {
+                return;
+            }
+
+            PosixFileAttributeView view = Files.getFileAttributeView(path, PosixFileAttributeView.class, LinkOption.NOFOLLOW_LINKS);
+
+            if (view != null) {
+                GroupPrincipal group = path.getFileSystem().getUserPrincipalLookupService().lookupPrincipalByGroupName(expectedGroup);
+
+                view.setGroup(group);
+            }
         }
 
         private void validateDirectory(Path directory, Set<PosixFilePermission> expectedPermissions, String expectedOwner, String expectedGroup, String label, String ownershipLabel) throws IOException {
@@ -222,6 +293,30 @@ public final class LocalDirectoryResolver {
 
                 if (expectedGroup != null && !StringUtils.equals(attrs.group().getName(), expectedGroup)) {
                     throw new IOException("Unexpected group on " + ownershipLabel + " " + directory + ": expected " + expectedGroup + ", actual " + attrs.group().getName());
+                }
+            }
+        }
+
+        private void validateFile(Path file, Set<PosixFilePermission> expectedPermissions, String expectedOwner, String expectedGroup, String label, String ownershipLabel) throws IOException {
+            if (Files.isSymbolicLink(file) || !Files.isRegularFile(file, LinkOption.NOFOLLOW_LINKS)) {
+                throw new IOException(label + " is not a regular file: " + file);
+            }
+
+            PosixFileAttributeView view = Files.getFileAttributeView(file, PosixFileAttributeView.class, LinkOption.NOFOLLOW_LINKS);
+
+            if (view != null) {
+                PosixFileAttributes attrs = view.readAttributes();
+
+                if (expectedPermissions != null && !attrs.permissions().equals(expectedPermissions)) {
+                    throw new IOException("Unsafe permissions on " + StringUtils.lowerCase(label) + " " + file + ": expected " + expectedPermissions + ", actual " + attrs.permissions());
+                }
+
+                if (expectedOwner != null && !StringUtils.equals(attrs.owner().getName(), expectedOwner)) {
+                    throw new IOException("Unexpected owner on " + ownershipLabel + " " + file + ": expected " + expectedOwner + ", actual " + attrs.owner().getName());
+                }
+
+                if (expectedGroup != null && !StringUtils.equals(attrs.group().getName(), expectedGroup)) {
+                    throw new IOException("Unexpected group on " + ownershipLabel + " " + file + ": expected " + expectedGroup + ", actual " + attrs.group().getName());
                 }
             }
         }

--- a/agents-audit/src/main/java/org/apache/ranger/audit/utils/LocalDirectoryResolver.java
+++ b/agents-audit/src/main/java/org/apache/ranger/audit/utils/LocalDirectoryResolver.java
@@ -1,0 +1,214 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ranger.audit.utils;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.security.UserGroupInformation;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.PosixFileAttributeView;
+import java.nio.file.attribute.PosixFileAttributes;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Set;
+
+public final class LocalDirectoryResolver {
+    public static final String SUBDIR_MODE_DISABLED = "disabled";
+    public static final String SUBDIR_MODE_PERUSER  = "peruser";
+    public static final String SUBDIR_MODE_PERGROUP = "pergroup";
+
+    private static final Set<PosixFilePermission> PERUSER_DIR_PERMS   = PosixFilePermissions.fromString("rwx------");
+    private static final Set<PosixFilePermission> PERUSER_FILE_PERMS  = PosixFilePermissions.fromString("rw-------");
+    private static final Set<PosixFilePermission> PERGROUP_DIR_PERMS  = PosixFilePermissions.fromString("rwxrwx---");
+    private static final Set<PosixFilePermission> PERGROUP_FILE_PERMS = PosixFilePermissions.fromString("rw-rw----");
+
+    private LocalDirectoryResolver() {
+    }
+
+    public static ResolvedDirectory resolveAuditSpool(String baseDir, String subdirMode, Set<PosixFilePermission> defaultDirPerms, Set<PosixFilePermission> defaultFilePerms) {
+        return resolve(baseDir, subdirMode, defaultDirPerms, defaultFilePerms, "audit spool", "Audit spool path", "Base audit spool directory", "audit spool directory");
+    }
+
+    public static ResolvedDirectory resolveLocalDirectory(String baseDir, String subdirMode, Set<PosixFilePermission> defaultDirPerms, Set<PosixFilePermission> defaultFilePerms) {
+        return resolve(baseDir, subdirMode, defaultDirPerms, defaultFilePerms, "local directory", "Local directory", "Base local directory", "local directory");
+    }
+
+    private static ResolvedDirectory resolve(String baseDir, String subdirMode, Set<PosixFilePermission> defaultDirPerms, Set<PosixFilePermission> defaultFilePerms, String subdirDescription, String directoryLabel, String baseDirectoryLabel, String ownershipLabel) {
+        String mode = StringUtils.defaultIfBlank(subdirMode, SUBDIR_MODE_DISABLED).trim().toLowerCase();
+
+        if (SUBDIR_MODE_DISABLED.equals(mode)) {
+            return new ResolvedDirectory(null, baseDir, null, defaultDirPerms, defaultFilePerms, null, null, directoryLabel, baseDirectoryLabel, ownershipLabel);
+        } else if (SUBDIR_MODE_PERUSER.equals(mode)) {
+            String user = sanitizePathElement(getCurrentUser(), "user", subdirDescription);
+
+            return new ResolvedDirectory(baseDir, appendPath(baseDir, user), defaultDirPerms, PERUSER_DIR_PERMS, PERUSER_FILE_PERMS, user, null, directoryLabel, baseDirectoryLabel, ownershipLabel);
+        } else if (SUBDIR_MODE_PERGROUP.equals(mode)) {
+            String group = sanitizePathElement(getCurrentGroup(subdirDescription), "group", subdirDescription);
+
+            return new ResolvedDirectory(baseDir, appendPath(baseDir, group), defaultDirPerms, PERGROUP_DIR_PERMS, PERGROUP_FILE_PERMS, null, group, directoryLabel, baseDirectoryLabel, ownershipLabel);
+        }
+
+        throw new IllegalArgumentException("Unsupported " + subdirDescription + " subdir mode: " + subdirMode);
+    }
+
+    private static String appendPath(String baseDir, String child) {
+        if (StringUtils.isBlank(baseDir)) {
+            return baseDir;
+        }
+
+        return new File(baseDir, child).getPath();
+    }
+
+    private static String sanitizePathElement(String value, String label, String subdirDescription) {
+        String ret = StringUtils.trim(value);
+
+        if (StringUtils.isBlank(ret) || ".".equals(ret) || "..".equals(ret) || ret.contains("..") ||
+                ret.indexOf('/') >= 0 || ret.indexOf('\\') >= 0 || ret.indexOf(File.separatorChar) >= 0 ||
+                ret.indexOf(File.pathSeparatorChar) >= 0) {
+            throw new IllegalArgumentException("Invalid " + label + " value for " + subdirDescription + " subdir: " + value);
+        }
+
+        return ret;
+    }
+
+    private static String getCurrentUser() {
+        try {
+            UserGroupInformation ugi = UserGroupInformation.getCurrentUser();
+
+            if (ugi != null && StringUtils.isNotBlank(ugi.getShortUserName())) {
+                return ugi.getShortUserName();
+            }
+        } catch (IOException ignored) {
+        }
+
+        return System.getProperty("user.name");
+    }
+
+    private static String getCurrentGroup(String subdirDescription) {
+        try {
+            UserGroupInformation ugi = UserGroupInformation.getCurrentUser();
+
+            if (ugi != null && StringUtils.isNotBlank(ugi.getPrimaryGroupName())) {
+                return ugi.getPrimaryGroupName();
+            }
+        } catch (IOException ignored) {
+        }
+
+        throw new IllegalStateException("Unable to determine current user's primary group for " + subdirDescription + " subdir");
+    }
+
+    public static final class ResolvedDirectory {
+        private final String                    basePath;
+        private final String                    path;
+        private final Set<PosixFilePermission> baseDirPermissions;
+        private final Set<PosixFilePermission> dirPermissions;
+        private final Set<PosixFilePermission> filePermissions;
+        private final String                    expectedOwner;
+        private final String                    expectedGroup;
+        private final String                    directoryLabel;
+        private final String                    baseDirectoryLabel;
+        private final String                    ownershipLabel;
+
+        private ResolvedDirectory(String basePath, String path, Set<PosixFilePermission> baseDirPermissions, Set<PosixFilePermission> dirPermissions, Set<PosixFilePermission> filePermissions, String expectedOwner, String expectedGroup, String directoryLabel, String baseDirectoryLabel, String ownershipLabel) {
+            this.basePath           = basePath;
+            this.path               = path;
+            this.baseDirPermissions = baseDirPermissions;
+            this.dirPermissions     = dirPermissions;
+            this.filePermissions    = filePermissions;
+            this.expectedOwner      = expectedOwner;
+            this.expectedGroup      = expectedGroup;
+            this.directoryLabel     = directoryLabel;
+            this.baseDirectoryLabel = baseDirectoryLabel;
+            this.ownershipLabel     = ownershipLabel;
+        }
+
+        public String getPath() {
+            return path;
+        }
+
+        public Set<PosixFilePermission> getDirPermissions() {
+            return dirPermissions;
+        }
+
+        public Set<PosixFilePermission> getFilePermissions() {
+            return filePermissions;
+        }
+
+        public void ensureDirectory() throws IOException {
+            if (StringUtils.isBlank(path)) {
+                return;
+            }
+
+            Path directory = Paths.get(path);
+
+            if (StringUtils.isNotBlank(basePath)) {
+                ensureBaseDirectory();
+            }
+
+            if (Files.exists(directory, LinkOption.NOFOLLOW_LINKS)) {
+                validateDirectory(directory, dirPermissions, expectedOwner, expectedGroup, directoryLabel, ownershipLabel);
+            } else if (StringUtils.isNotBlank(basePath)) {
+                Files.createDirectory(directory, PosixFilePermissions.asFileAttribute(dirPermissions));
+                Files.setPosixFilePermissions(directory, dirPermissions);
+                validateDirectory(directory, dirPermissions, expectedOwner, expectedGroup, directoryLabel, ownershipLabel);
+            } else {
+                Files.createDirectories(directory, PosixFilePermissions.asFileAttribute(dirPermissions));
+                Files.setPosixFilePermissions(directory, dirPermissions);
+                validateDirectory(directory, dirPermissions, expectedOwner, expectedGroup, directoryLabel, ownershipLabel);
+            }
+        }
+
+        private void ensureBaseDirectory() throws IOException {
+            Path baseDirectory = Paths.get(basePath);
+
+            if (!Files.exists(baseDirectory, LinkOption.NOFOLLOW_LINKS)) {
+                throw new IOException(baseDirectoryLabel + " does not exist: " + baseDirectory);
+            }
+
+            validateDirectory(baseDirectory, baseDirPermissions, null, null, baseDirectoryLabel, ownershipLabel);
+        }
+
+        private void validateDirectory(Path directory, Set<PosixFilePermission> expectedPermissions, String expectedOwner, String expectedGroup, String label, String ownershipLabel) throws IOException {
+            if (Files.isSymbolicLink(directory) || !Files.isDirectory(directory, LinkOption.NOFOLLOW_LINKS)) {
+                throw new IOException(label + " is not a regular directory: " + directory);
+            }
+
+            PosixFileAttributeView view = Files.getFileAttributeView(directory, PosixFileAttributeView.class, LinkOption.NOFOLLOW_LINKS);
+
+            if (view != null) {
+                PosixFileAttributes attrs = view.readAttributes();
+
+                if (expectedPermissions != null && !attrs.permissions().equals(expectedPermissions)) {
+                    throw new IOException("Unsafe permissions on " + StringUtils.lowerCase(label) + " " + directory + ": expected " + expectedPermissions + ", actual " + attrs.permissions());
+                }
+
+                if (expectedOwner != null && !StringUtils.equals(attrs.owner().getName(), expectedOwner)) {
+                    throw new IOException("Unexpected owner on " + ownershipLabel + " " + directory + ": expected " + expectedOwner + ", actual " + attrs.owner().getName());
+                }
+
+                if (expectedGroup != null && !StringUtils.equals(attrs.group().getName(), expectedGroup)) {
+                    throw new IOException("Unexpected group on " + ownershipLabel + " " + directory + ": expected " + expectedGroup + ", actual " + attrs.group().getName());
+                }
+            }
+        }
+    }
+}

--- a/agents-audit/src/test/java/org/apache/ranger/audit/queue/AuditFileSpoolTest.java
+++ b/agents-audit/src/test/java/org/apache/ranger/audit/queue/AuditFileSpoolTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ranger.audit.queue;
+
+import org.apache.ranger.audit.provider.DummyAuditProvider;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Comparator;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class AuditFileSpoolTest {
+    @Test
+    public void testSolrBatchFileSpoolSubdirModeIsApplied() throws Exception {
+        Path baseDir = Files.createTempDirectory("audit-solr-spool");
+
+        try {
+            Files.setPosixFilePermissions(baseDir, PosixFilePermissions.fromString("rwxr-xr-x"));
+
+            String     propPrefix = "xasecure.audit.destination.solr.batch";
+            Properties props      = new Properties();
+
+            props.setProperty(propPrefix + "." + AuditFileSpool.PROP_FILE_SPOOL_LOCAL_DIR, baseDir.toString());
+            props.setProperty(propPrefix + "." + AuditFileSpool.PROP_FILE_SPOOL_SUBDIR_MODE, "peruser");
+
+            DummyAuditProvider consumer = new DummyAuditProvider();
+            AuditFileSpool     spool    = new AuditFileSpool(new AuditBatchQueue(consumer), consumer);
+
+            assertTrue(spool.init(props, propPrefix));
+            assertEquals(baseDir, spool.logFolder.toPath().getParent());
+            assertTrue(Files.isDirectory(spool.logFolder.toPath()));
+            assertEquals(PosixFilePermissions.fromString("rwx------"), Files.getPosixFilePermissions(spool.logFolder.toPath()));
+        } finally {
+            deleteRecursively(baseDir);
+        }
+    }
+
+    private static void deleteRecursively(Path path) throws IOException {
+        if (path == null || !Files.exists(path)) {
+            return;
+        }
+
+        try (java.util.stream.Stream<Path> paths = Files.walk(path)) {
+            paths.sorted(Comparator.reverseOrder()).forEach(currentPath -> {
+                try {
+                    Files.deleteIfExists(currentPath);
+                } catch (IOException ignored) {
+                }
+            });
+        }
+    }
+}

--- a/agents-audit/src/test/java/org/apache/ranger/audit/utils/AuditFileUtilTest.java
+++ b/agents-audit/src/test/java/org/apache/ranger/audit/utils/AuditFileUtilTest.java
@@ -28,7 +28,9 @@ import java.util.Comparator;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class AuditFileUtilTest {
 
@@ -145,6 +147,139 @@ public class AuditFileUtilTest {
                             Files.delete(path);
                         } catch (IOException e) {
                             // Ignore cleanup exceptions
+                        }
+                    });
+        }
+    }
+
+    @Test
+    public void testResolvePerUserDirectoryUsesPrivatePermissions() throws Exception {
+        Path tempBaseDir = Files.createTempDirectory("auditSpoolDir");
+        try {
+            Files.setPosixFilePermissions(tempBaseDir, PosixFilePermissions.fromString("rwxr-xr-x"));
+            AuditFileUtil.ResolvedDirectory directory = AuditFileUtil.resolveDirectory(tempBaseDir.toString(),
+                    AuditFileUtil.SUBDIR_MODE_PERUSER,
+                    AuditFileUtil.parsePermissions("755"),
+                    AuditFileUtil.parsePermissions("644"));
+
+            directory.ensureDirectory();
+
+            Path resolvedPath = new File(directory.getPath()).toPath();
+            assertTrue("Directory should exist", Files.isDirectory(resolvedPath));
+            assertEquals("Base directory permissions should not be changed", PosixFilePermissions.fromString("rwxr-xr-x"), Files.getPosixFilePermissions(tempBaseDir));
+            assertEquals("Directory permissions should be private", PosixFilePermissions.fromString("rwx------"), Files.getPosixFilePermissions(resolvedPath));
+            assertEquals("File permissions should be private", PosixFilePermissions.fromString("rw-------"), directory.getFilePermissions());
+        } finally {
+            deleteRecursively(tempBaseDir);
+        }
+    }
+
+    @Test
+    public void testResolvePerGroupDirectoryUsesGroupPermissions() throws Exception {
+        Path tempBaseDir = Files.createTempDirectory("auditSpoolDir");
+        try {
+            Files.setPosixFilePermissions(tempBaseDir, PosixFilePermissions.fromString("rwxr-xr-x"));
+            AuditFileUtil.ResolvedDirectory directory = AuditFileUtil.resolveDirectory(tempBaseDir.toString(),
+                    AuditFileUtil.SUBDIR_MODE_PERGROUP,
+                    AuditFileUtil.parsePermissions("755"),
+                    AuditFileUtil.parsePermissions("644"));
+
+            directory.ensureDirectory();
+
+            Path resolvedPath = new File(directory.getPath()).toPath();
+            assertTrue("Directory should exist", Files.isDirectory(resolvedPath));
+            assertEquals("Base directory permissions should not be changed", PosixFilePermissions.fromString("rwxr-xr-x"), Files.getPosixFilePermissions(tempBaseDir));
+            assertEquals("Directory permissions should be group-scoped", PosixFilePermissions.fromString("rwxrwx---"), Files.getPosixFilePermissions(resolvedPath));
+            assertEquals("File permissions should be group-scoped", PosixFilePermissions.fromString("rw-rw----"), directory.getFilePermissions());
+        } finally {
+            deleteRecursively(tempBaseDir);
+        }
+    }
+
+    @Test(expected = IOException.class)
+    public void testResolveDirectoryRejectsUnsafeExistingPermissions() throws Exception {
+        Path tempBaseDir = Files.createTempDirectory("auditSpoolDir");
+        try {
+            Files.setPosixFilePermissions(tempBaseDir, PosixFilePermissions.fromString("rwxr-xr-x"));
+            AuditFileUtil.ResolvedDirectory directory = AuditFileUtil.resolveDirectory(tempBaseDir.toString(),
+                    AuditFileUtil.SUBDIR_MODE_PERUSER,
+                    AuditFileUtil.parsePermissions("755"),
+                    AuditFileUtil.parsePermissions("644"));
+            Path resolvedPath = new File(directory.getPath()).toPath();
+
+            Files.createDirectories(resolvedPath);
+            Files.setPosixFilePermissions(resolvedPath, PosixFilePermissions.fromString("rwxr-xr-x"));
+
+            directory.ensureDirectory();
+        } finally {
+            deleteRecursively(tempBaseDir);
+        }
+    }
+
+    @Test
+    public void testResolvePerUserDirectoryRequiresExistingBaseDirectory() throws Exception {
+        Path tempDir = Files.createTempDirectory("auditSpoolDirParent");
+
+        try {
+            Path baseDir = tempDir.resolve("audit-spool");
+            AuditFileUtil.ResolvedDirectory directory = AuditFileUtil.resolveDirectory(baseDir.toString(),
+                    AuditFileUtil.SUBDIR_MODE_PERUSER,
+                    AuditFileUtil.parsePermissions("755"),
+                    AuditFileUtil.parsePermissions("644"));
+
+            try {
+                directory.ensureDirectory();
+                fail("Expected missing base audit spool directory to be rejected");
+            } catch (IOException exception) {
+                assertTrue(exception.getMessage().contains("Base audit spool directory does not exist"));
+            }
+
+            assertFalse(Files.exists(baseDir));
+        } finally {
+            deleteRecursively(tempDir);
+        }
+    }
+
+    @Test
+    public void testResolvePerUserDirectoryRejectsUnsafeBasePermissions() throws Exception {
+        Path tempBaseDir = Files.createTempDirectory("auditSpoolDir");
+
+        try {
+            AuditFileUtil.ResolvedDirectory directory = AuditFileUtil.resolveDirectory(tempBaseDir.toString(),
+                    AuditFileUtil.SUBDIR_MODE_PERUSER,
+                    AuditFileUtil.parsePermissions("755"),
+                    AuditFileUtil.parsePermissions("644"));
+            Path resolvedPath = new File(directory.getPath()).toPath();
+
+            try {
+                directory.ensureDirectory();
+                fail("Expected unsafe base audit spool permissions to be rejected");
+            } catch (IOException exception) {
+                assertTrue(exception.getMessage().contains("Unsafe permissions on base audit spool directory"));
+            }
+
+            assertFalse(Files.exists(resolvedPath));
+        } finally {
+            deleteRecursively(tempBaseDir);
+        }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testResolveDirectoryRejectsUnknownMode() {
+        AuditFileUtil.resolveDirectory("/tmp/ranger-audit", "unknown", AuditFileUtil.parsePermissions("755"), AuditFileUtil.parsePermissions("644"));
+    }
+
+    private static void deleteRecursively(Path path) throws IOException {
+        if (path == null || !Files.exists(path)) {
+            return;
+        }
+
+        try (java.util.stream.Stream<Path> paths = Files.walk(path)) {
+            paths.sorted(Comparator.reverseOrder())
+                    .forEach(currentPath -> {
+                        try {
+                            Files.deleteIfExists(currentPath);
+                        } catch (IOException ignored) {
                         }
                     });
         }

--- a/agents-audit/src/test/java/org/apache/ranger/audit/utils/AuditFileUtilTest.java
+++ b/agents-audit/src/test/java/org/apache/ranger/audit/utils/AuditFileUtilTest.java
@@ -24,8 +24,15 @@ import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
+import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -191,6 +198,47 @@ public class AuditFileUtilTest {
             assertEquals("Base directory permissions should not be changed", PosixFilePermissions.fromString("rwxr-xr-x"), Files.getPosixFilePermissions(tempBaseDir));
             assertEquals("Directory permissions should be group-scoped", PosixFilePermissions.fromString("rwxrwx---"), Files.getPosixFilePermissions(resolvedPath));
             assertEquals("File permissions should be group-scoped", PosixFilePermissions.fromString("rw-rw----"), directory.getFilePermissions());
+        } finally {
+            deleteRecursively(tempBaseDir);
+        }
+    }
+
+    @Test
+    public void testResolvePerGroupDirectoryHandlesConcurrentCreation() throws Exception {
+        Path tempBaseDir = Files.createTempDirectory("auditSpoolDir");
+
+        try {
+            Files.setPosixFilePermissions(tempBaseDir, PosixFilePermissions.fromString("rwxr-xr-x"));
+            final AuditFileUtil.ResolvedDirectory directory = AuditFileUtil.resolveDirectory(tempBaseDir.toString(),
+                    AuditFileUtil.SUBDIR_MODE_PERGROUP,
+                    AuditFileUtil.parsePermissions("755"),
+                    AuditFileUtil.parsePermissions("644"));
+            int threadCount = 8;
+            ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+
+            try {
+                final CyclicBarrier startBarrier = new CyclicBarrier(threadCount);
+                List<Future<Void>> futures = new ArrayList<>();
+
+                for (int i = 0; i < threadCount; i++) {
+                    futures.add(executorService.submit(() -> {
+                        startBarrier.await(10, TimeUnit.SECONDS);
+                        directory.ensureDirectory();
+                        return null;
+                    }));
+                }
+
+                for (Future<Void> future : futures) {
+                    future.get(10, TimeUnit.SECONDS);
+                }
+            } finally {
+                executorService.shutdownNow();
+                assertTrue("Executor should terminate", executorService.awaitTermination(10, TimeUnit.SECONDS));
+            }
+
+            Path resolvedPath = new File(directory.getPath()).toPath();
+            assertTrue("Directory should exist", Files.isDirectory(resolvedPath));
+            assertEquals("Directory permissions should be group-scoped", PosixFilePermissions.fromString("rwxrwx---"), Files.getPosixFilePermissions(resolvedPath));
         } finally {
             deleteRecursively(tempBaseDir);
         }

--- a/agents-common/src/main/java/org/apache/ranger/admin/client/RangerAdminClientAccessDeniedException.java
+++ b/agents-common/src/main/java/org/apache/ranger/admin/client/RangerAdminClientAccessDeniedException.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.admin.client;
+
+public class RangerAdminClientAccessDeniedException extends Exception {
+	private final int httpStatus;
+
+	public RangerAdminClientAccessDeniedException(int httpStatus, String message) {
+		super(message);
+		this.httpStatus = httpStatus;
+	}
+
+	public int getHttpStatus() {
+		return httpStatus;
+	}
+}

--- a/agents-common/src/main/java/org/apache/ranger/admin/client/RangerAdminRESTClient.java
+++ b/agents-common/src/main/java/org/apache/ranger/admin/client/RangerAdminRESTClient.java
@@ -22,12 +22,12 @@
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.sun.jersey.api.client.ClientResponse;
+import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.security.PrivilegedExceptionAction;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.core.Cookie;
 import javax.ws.rs.core.NewCookie;
@@ -150,17 +150,16 @@ public class RangerAdminRESTClient extends AbstractRangerAdminClient {
 
 		checkAndResetSessionCookie(response);
 
-		if (response == null || response.getStatus() == HttpServletResponse.SC_NOT_MODIFIED || response.getStatus() == HttpServletResponse.SC_NO_CONTENT) {
-			if (response == null) {
-				LOG.error("Error getting policies; Received NULL response!!. secureMode=" + isSecureMode + ", user=" + user + ", serviceName=" + serviceName);
-			} else {
-				RESTResponse resp = RESTResponse.fromClientResponse(response);
-				if (LOG.isDebugEnabled()) {
-					LOG.debug("No change in policies. secureMode=" + isSecureMode + ", user=" + user
-									  + ", response=" + resp + ", serviceName=" + serviceName
-									  + ", " + "lastKnownVersion=" + lastKnownVersion
-									  + ", " + "lastActivationTimeInMillis=" + lastActivationTimeInMillis);
-				}
+		if (response == null) {
+            LOG.error("Error getting policies; Received NULL response!!. secureMode={}, user={}, serviceName={}", isSecureMode, user, serviceName);
+			throw new IOException("Error getting policies; received null response for serviceName=" + serviceName);
+		} else if (response.getStatus() == HttpServletResponse.SC_NOT_MODIFIED || response.getStatus() == HttpServletResponse.SC_NO_CONTENT) {
+			RESTResponse resp = RESTResponse.fromClientResponse(response);
+			if (LOG.isDebugEnabled()) {
+				LOG.debug("No change in policies. secureMode=" + isSecureMode + ", user=" + user
+								  + ", response=" + resp + ", serviceName=" + serviceName
+								  + ", " + "lastKnownVersion=" + lastKnownVersion
+								  + ", " + "lastActivationTimeInMillis=" + lastActivationTimeInMillis);
 			}
 			ret = null;
 		} else if (response.getStatus() == HttpServletResponse.SC_OK) {
@@ -176,10 +175,14 @@ public class RangerAdminRESTClient extends AbstractRangerAdminClient {
 			RangerServiceNotFoundException.throwExceptionIfServiceNotFound(serviceName, exceptionMsg);
 
 			LOG.warn("Received 404 error code with body:[" + exceptionMsg + "], Ignoring");
+		} else if (isAccessDenied(response)) {
+			RESTResponse resp = RESTResponse.fromClientResponse(response);
+			LOG.warn("Error getting policies. secureMode=" + isSecureMode + ", user=" + user + ", response=" + resp + ", serviceName=" + serviceName);
+			throw new RangerAdminClientAccessDeniedException(response.getStatus(), resp.getMessage());
 		} else {
 			RESTResponse resp = RESTResponse.fromClientResponse(response);
 			LOG.warn("Error getting policies. secureMode=" + isSecureMode + ", user=" + user + ", response=" + resp + ", serviceName=" + serviceName);
-			ret = null;
+			throw new IOException("Error getting policies. response=" + resp + ", serviceName=" + serviceName);
 		}
 
 		if (LOG.isDebugEnabled()) {
@@ -215,17 +218,19 @@ public class RangerAdminRESTClient extends AbstractRangerAdminClient {
 
 		checkAndResetSessionCookie(response);
 
-		if (response == null || response.getStatus() == HttpServletResponse.SC_NOT_MODIFIED || response.getStatus() == HttpServletResponse.SC_NO_CONTENT) {
-			if (response == null) {
-				LOG.error("Error getting Roles; Received NULL response!!. secureMode=" + isSecureMode + ", user=" + user + ", serviceName=" + serviceName);
-			} else {
-				RESTResponse resp = RESTResponse.fromClientResponse(response);
-				if (LOG.isDebugEnabled()) {
-					LOG.debug("No change in Roles. secureMode=" + isSecureMode + ", user=" + user
-									  + ", response=" + resp + ", serviceName=" + serviceName
-									  + ", " + "lastKnownRoleVersion=" + lastKnownRoleVersion
-									  + ", " + "lastActivationTimeInMillis=" + lastActivationTimeInMillis);
-				}
+		if (response == null) {
+            LOG.error("Error getting Roles; Received NULL response!!. secureMode={}, user={}, serviceName={}", isSecureMode, user, serviceName);
+			throw new IOException("Error getting Roles; received null response for serviceName=" + serviceName);
+		} else if (response.getStatus() == HttpServletResponse.SC_NOT_MODIFIED || response.getStatus() == HttpServletResponse.SC_NO_CONTENT) {
+			RESTResponse resp = RESTResponse.fromClientResponse(response);
+			if (LOG.isDebugEnabled()) {
+                LOG.debug("No change in Roles. secureMode={}, user={}, response={}, serviceName={}, lastKnownRoleVersion={}, lastActivationTimeInMillis={}",
+                        isSecureMode,
+                        user,
+                        resp,
+                        serviceName,
+                        lastKnownRoleVersion,
+                        lastActivationTimeInMillis);
 			}
 			ret = null;
 		} else if (response.getStatus() == HttpServletResponse.SC_OK) {
@@ -241,10 +246,14 @@ public class RangerAdminRESTClient extends AbstractRangerAdminClient {
 			RangerServiceNotFoundException.throwExceptionIfServiceNotFound(serviceName, exceptionMsg);
 
 			LOG.warn("Received 404 error code with body:[" + exceptionMsg + "], Ignoring");
+		} else if (isAccessDenied(response)) {
+			RESTResponse resp = RESTResponse.fromClientResponse(response);
+			LOG.warn("Error getting Roles. secureMode=" + isSecureMode + ", user=" + user + ", response=" + resp + ", serviceName=" + serviceName);
+			throw new RangerAdminClientAccessDeniedException(response.getStatus(), resp.getMessage());
 		} else {
 			RESTResponse resp = RESTResponse.fromClientResponse(response);
 			LOG.warn("Error getting Roles. secureMode=" + isSecureMode + ", user=" + user + ", response=" + resp + ", serviceName=" + serviceName);
-			ret = null;
+			throw new IOException("Error getting Roles. response=" + resp + ", serviceName=" + serviceName);
 		}
 
 		if(LOG.isDebugEnabled()) {
@@ -790,17 +799,19 @@ public class RangerAdminRESTClient extends AbstractRangerAdminClient {
 
 		checkAndResetSessionCookie(response);
 
-		if (response == null || response.getStatus() == HttpServletResponse.SC_NOT_MODIFIED) {
-			if (response == null) {
-				LOG.error("Error getting tags; Received NULL response!!. secureMode=" + isSecureMode + ", user=" + user + ", serviceName=" + serviceName);
-			} else {
-				RESTResponse resp = RESTResponse.fromClientResponse(response);
-				if (LOG.isDebugEnabled()) {
-					LOG.debug("No change in tags. secureMode=" + isSecureMode + ", user=" + user
-									  + ", response=" + resp + ", serviceName=" + serviceName
-									  + ", " + "lastKnownVersion=" + lastKnownVersion
-									  + ", " + "lastActivationTimeInMillis=" + lastActivationTimeInMillis);
-				}
+		if (response == null) {
+            LOG.error("Error getting tags; Received NULL response!!. secureMode={}, user={}, serviceName={}", isSecureMode, user, serviceName);
+			throw new IOException("Error getting tags; received null response for serviceName=" + serviceName);
+		} else if (response.getStatus() == HttpServletResponse.SC_NOT_MODIFIED) {
+			RESTResponse resp = RESTResponse.fromClientResponse(response);
+			if (LOG.isDebugEnabled()) {
+                LOG.debug("No change in tags. secureMode={}, user={}, response={}, serviceName={}, lastKnownVersion={}, lastActivationTimeInMillis={}",
+                        isSecureMode,
+                        user,
+                        resp,
+                        serviceName,
+                        lastKnownVersion,
+                        lastActivationTimeInMillis);
 			}
 			ret = null;
 		} else if (response.getStatus() == HttpServletResponse.SC_OK) {
@@ -815,10 +826,14 @@ public class RangerAdminRESTClient extends AbstractRangerAdminClient {
 			String exceptionMsg = response.hasEntity() ? response.getEntity(String.class) : null;
 			RangerServiceNotFoundException.throwExceptionIfServiceNotFound(serviceName, exceptionMsg);
 			LOG.warn("Received 404 error code with body:[" + exceptionMsg + "], Ignoring");
+		} else if (isAccessDenied(response)) {
+			RESTResponse resp = RESTResponse.fromClientResponse(response);
+			LOG.warn("Error getting tags. secureMode=" + isSecureMode + ", user=" + user + ", response=" + resp + ", serviceName=" + serviceName);
+			throw new RangerAdminClientAccessDeniedException(response.getStatus(), resp.getMessage());
 		} else {
 			RESTResponse resp = RESTResponse.fromClientResponse(response);
 			LOG.warn("Error getting tags. secureMode=" + isSecureMode + ", user=" + user + ", response=" + resp + ", serviceName=" + serviceName);
-			ret = null;
+			throw new IOException("Error getting tags. response=" + resp + ", serviceName=" + serviceName);
 		}
 
 		if(LOG.isDebugEnabled()) {
@@ -1153,6 +1168,12 @@ public class RangerAdminRESTClient extends AbstractRangerAdminClient {
 			}
 			return null;
 		});
+	}
+
+	private boolean isAccessDenied(ClientResponse response) {
+		int status = response == null ? 0 : response.getStatus();
+
+		return status == HttpServletResponse.SC_UNAUTHORIZED || status == HttpServletResponse.SC_FORBIDDEN;
 	}
 
 	private void checkAndResetSessionCookie(ClientResponse response) {

--- a/agents-common/src/main/java/org/apache/ranger/plugin/contextenricher/RangerAdminTagRetriever.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/contextenricher/RangerAdminTagRetriever.java
@@ -21,6 +21,7 @@ package org.apache.ranger.plugin.contextenricher;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.ranger.admin.client.RangerAdminClient;
+import org.apache.ranger.admin.client.RangerAdminClientAccessDeniedException;
 import org.apache.ranger.authorization.hadoop.config.RangerPluginConfig;
 import org.apache.ranger.plugin.policyengine.RangerPluginContext;
 import org.apache.ranger.plugin.util.ServiceTags;
@@ -65,9 +66,12 @@ public class RangerAdminTagRetriever extends RangerTagRetriever {
 			} catch (ClosedByInterruptException closedByInterruptException) {
 				LOG.error("Tag-retriever thread was interrupted while blocked on I/O");
 				throw new InterruptedException();
+			} catch (RangerAdminClientAccessDeniedException ade) {
+				LOG.warn("Tag-retriever encountered authorization denial", ade);
+				throw ade;
 			} catch (Exception e) {
-				LOG.error("Tag-retriever encounterd exception, exception=", e);
-				LOG.error("Returning null service tags");
+				LOG.error("Tag-retriever encountered exception", e);
+				throw e;
 			}
 		}
 
@@ -75,4 +79,3 @@ public class RangerAdminTagRetriever extends RangerTagRetriever {
 	}
 
 }
-

--- a/agents-common/src/main/java/org/apache/ranger/plugin/contextenricher/RangerTagEnricher.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/contextenricher/RangerTagEnricher.java
@@ -1131,8 +1131,8 @@ public class RangerTagEnricher extends RangerAbstractContextEnricher {
 						cacheDirectory.ensureDirectory();
 						if (!cacheFile.exists()) {
 							Files.createFile(cacheFile.toPath(), PosixFilePermissions.asFileAttribute(this.filePermissions));
-							Files.setPosixFilePermissions(cacheFile.toPath(), this.filePermissions);
 						}
+						cacheDirectory.secureFile(cacheFile);
 						writer = new FileWriter(cacheFile);
 						JsonUtils.objectToWriter(writer, serviceTags);
 					} catch (Exception excp) {

--- a/agents-common/src/main/java/org/apache/ranger/plugin/contextenricher/RangerTagEnricher.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/contextenricher/RangerTagEnricher.java
@@ -22,6 +22,7 @@ package org.apache.ranger.plugin.contextenricher;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.ranger.admin.client.RangerAdminClientAccessDeniedException;
 import org.apache.ranger.authorization.hadoop.config.RangerPluginConfig;
 import org.apache.ranger.authorization.utils.JsonUtils;
 import org.apache.ranger.plugin.model.RangerPolicy;
@@ -109,7 +110,7 @@ public class RangerTagEnricher extends RangerAbstractContextEnricher {
 		serviceDefHelper           = new RangerServiceDefHelper(serviceDef, false);
 
 		String cacheFilePermsString = StringUtils.trim(getConfig(propertyPrefix + ".policy.cache.file.perms", "644"));
-		this.cacheFilePerms = FileUtils.parsePermissions(cacheFilePermsString);
+		Set<PosixFilePermission> configuredCacheFilePerms = FileUtils.parsePermissions(cacheFilePermsString);
 
 		if (StringUtils.isNotBlank(tagRetrieverClassName)) {
 
@@ -132,12 +133,18 @@ public class RangerTagEnricher extends RangerAbstractContextEnricher {
 			if (tagRetriever != null) {
 				disableCacheIfServiceNotFound = getBooleanConfig(propertyPrefix + ".disable.cache.if.servicenotfound", true);
 				String cacheDir      = getConfig(propertyPrefix + ".policy.cache.dir", null);
+				String cacheDirPermsString = StringUtils.trim(getConfig(propertyPrefix + ".policy.cache.dir.perms", "755"));
+				RangerLocalDirectory.ResolvedDirectory cacheDirectory = RangerLocalDirectory.resolve(cacheDir,
+						getConfig(propertyPrefix + ".policy.cache.subdir.mode", RangerLocalDirectory.SUBDIR_MODE_DISABLED),
+						FileUtils.parsePermissions(cacheDirPermsString),
+						configuredCacheFilePerms);
 				String cacheFilename = String.format("%s_%s_tag.json", appId, serviceName);
 
 				cacheFilename = cacheFilename.replace(File.separatorChar,  '_');
 				cacheFilename = cacheFilename.replace(File.pathSeparatorChar,  '_');
 
-				String cacheFile = cacheDir == null ? null : (cacheDir + File.separator + cacheFilename);
+				this.cacheFilePerms = cacheDirectory.getFilePermissions();
+				String cacheFile = cacheDirectory.getPath() == null ? null : (cacheDirectory.getPath() + File.separator + cacheFilename);
 
 				createLock();
 
@@ -148,7 +155,7 @@ public class RangerTagEnricher extends RangerAbstractContextEnricher {
 				tagRetriever.setPluginContext(getPluginContext());
 				tagRetriever.init(enricherDef.getEnricherOptions());
 
-				tagRefresher = new RangerTagRefresher(tagRetriever, this, -1L, tagDownloadQueue, cacheFile, cacheFilePerms);
+				tagRefresher = new RangerTagRefresher(tagRetriever, this, -1L, tagDownloadQueue, cacheDirectory, cacheFile, cacheFilePerms);
 				LOG.info("Created RangerTagRefresher Thread(" + tagRefresher.getName() + ")");
 
 				try {
@@ -885,14 +892,16 @@ public class RangerTagEnricher extends RangerAbstractContextEnricher {
 		private final BlockingQueue<DownloadTrigger> tagDownloadQueue;
 		private long lastActivationTimeInMillis;
 		private final  Set<PosixFilePermission> filePermissions;
+		private final RangerLocalDirectory.ResolvedDirectory cacheDirectory;
 		private final String cacheFile;
 		private boolean      hasProvidedTagsToReceiver;
 
-		RangerTagRefresher(RangerTagRetriever tagRetriever, RangerTagEnricher tagEnricher, long lastKnownVersion, BlockingQueue<DownloadTrigger> tagDownloadQueue, String cacheFile, Set<PosixFilePermission> filePermissions) {
+		RangerTagRefresher(RangerTagRetriever tagRetriever, RangerTagEnricher tagEnricher, long lastKnownVersion, BlockingQueue<DownloadTrigger> tagDownloadQueue, RangerLocalDirectory.ResolvedDirectory cacheDirectory, String cacheFile, Set<PosixFilePermission> filePermissions) {
 			this.tagRetriever = tagRetriever;
 			this.tagEnricher = tagEnricher;
 			this.lastKnownVersion = lastKnownVersion;
 			this.tagDownloadQueue = tagDownloadQueue;
+			this.cacheDirectory = cacheDirectory;
 			this.cacheFile = cacheFile;
 			this.filePermissions = filePermissions;
 			setName("RangerTagRefresher(serviceName=" + tagRetriever.getServiceName() + ")-" + getId());
@@ -949,6 +958,7 @@ public class RangerTagEnricher extends RangerAbstractContextEnricher {
 
 				try {
 					serviceTags = tagRetriever.retrieveTags(lastKnownVersion, lastActivationTimeInMillis);
+					tagEnricher.getPluginContext().setTagDownloadAuthzDenied(false);
 
 					if (serviceTags == null) {
 						if (!hasProvidedTagsToReceiver) {
@@ -983,10 +993,23 @@ public class RangerTagEnricher extends RangerAbstractContextEnricher {
 						setLastActivationTimeInMillis(System.currentTimeMillis());
 						lastKnownVersion = -1L;
 					}
+				} catch (RangerAdminClientAccessDeniedException ade) {
+                    LOG.warn("RangerTagRefresher(serviceName={}).populateTags(): tag refresh authorization denied. Access checks will fail closed if configured.", tagRetriever.getServiceName(), ade);
+					tagEnricher.getPluginContext().setTagDownloadAuthzDenied(true);
 				} catch (InterruptedException interruptedException) {
 					throw interruptedException;
 				} catch (Exception e) {
-					LOG.error("RangerTagRefresher(serviceName=" + tagRetriever.getServiceName() + ").populateTags(): Encountered unexpected exception. Ignoring", e);
+                    LOG.error("RangerTagRefresher(serviceName={}).populateTags(): Encountered unexpected exception. Ignoring", tagRetriever.getServiceName(), e);
+					if (!hasProvidedTagsToReceiver) {
+						ServiceTags cachedServiceTags = loadFromCache();
+
+						if (cachedServiceTags != null) {
+							tagEnricher.setServiceTags(cachedServiceTags);
+							hasProvidedTagsToReceiver = true;
+							lastKnownVersion = cachedServiceTags.getTagVersion() == null ? -1L : cachedServiceTags.getTagVersion();
+							setLastActivationTimeInMillis(System.currentTimeMillis());
+						}
+					}
 				}
 
 			} else {
@@ -1051,6 +1074,13 @@ public class RangerTagEnricher extends RangerAbstractContextEnricher {
 
 			File cacheFile = StringUtils.isEmpty(this.cacheFile) ? null : new File(this.cacheFile);
 
+			try {
+				cacheDirectory.ensureDirectory();
+			} catch (Exception excp) {
+				LOG.error("failed to validate service-tags cache directory", excp);
+				return null;
+			}
+
 			if (cacheFile != null && cacheFile.isFile() && cacheFile.canRead()) {
 				Reader reader = null;
 
@@ -1098,6 +1128,7 @@ public class RangerTagEnricher extends RangerAbstractContextEnricher {
 					Writer writer = null;
 
 					try {
+						cacheDirectory.ensureDirectory();
 						if (!cacheFile.exists()) {
 							Files.createFile(cacheFile.toPath(), PosixFilePermissions.asFileAttribute(this.filePermissions));
 							Files.setPosixFilePermissions(cacheFile.toPath(), this.filePermissions);

--- a/agents-common/src/main/java/org/apache/ranger/plugin/policyengine/RangerPluginContext.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/policyengine/RangerPluginContext.java
@@ -41,6 +41,9 @@ public class RangerPluginContext {
 	private          RangerAuthContext                                                          authContext;
 	private          RangerAuthContextListener                                                  authContextListener;
 	private          RangerAdminClient                                                          adminClient;
+	private volatile boolean                                                                    policyDownloadAuthzDenied;
+	private volatile boolean                                                                    roleDownloadAuthzDenied;
+	private volatile boolean                                                                    tagDownloadAuthzDenied;
 	private	final 	 Map<String, Map<RangerPolicy.RangerPolicyResource, RangerResourceMatcher>> resourceMatchers = new HashMap<>();
 	private final    ReentrantReadWriteLock                                                     lock = new ReentrantReadWriteLock(true); // fair lock
 
@@ -123,6 +126,16 @@ public class RangerPluginContext {
 	public void setAuthContext(RangerAuthContext authContext) { this.authContext = authContext; }
 
 	public void setAuthContextListener(RangerAuthContextListener authContextListener) { this.authContextListener = authContextListener; }
+
+	public boolean isPolicyRefreshAuthzDenied() {
+		return policyDownloadAuthzDenied || roleDownloadAuthzDenied || tagDownloadAuthzDenied;
+	}
+
+	public void setPolicyDownloadAuthzDenied(boolean policyDownloadAuthzDenied) { this.policyDownloadAuthzDenied = policyDownloadAuthzDenied; }
+
+	public void setRoleDownloadAuthzDenied(boolean roleDownloadAuthzDenied) { this.roleDownloadAuthzDenied = roleDownloadAuthzDenied; }
+
+	public void setTagDownloadAuthzDenied(boolean tagDownloadAuthzDenied) { this.tagDownloadAuthzDenied = tagDownloadAuthzDenied; }
 
 	public void notifyAuthContextChanged() {
 		RangerAuthContextListener authContextListener = this.authContextListener;

--- a/agents-common/src/main/java/org/apache/ranger/plugin/service/RangerBasePlugin.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/service/RangerBasePlugin.java
@@ -68,6 +68,7 @@ public class RangerBasePlugin {
 	private final Map<String, LogHistory>     logHistoryList = new Hashtable<>();
 	private final int                         logInterval    = 30000; // 30 seconds
 	private final DownloadTrigger             accessTrigger  = new DownloadTrigger();
+	private final boolean                     failClosedOnPolicyRefreshAuthzDenied;
 	private       PolicyRefresher             refresher;
 	private       RangerPolicyEngine          policyEngine;
 	private       RangerAuthContext           currentAuthContext;
@@ -113,6 +114,9 @@ public class RangerBasePlugin {
 		setAuditExcludedUsersGroupsRoles(auditExcludeUsers, auditExcludeGroups, auditExcludeRoles);
 		setIsFallbackSupported(pluginConfig.getBoolean(pluginConfig.getPropertyPrefix() + ".is.fallback.supported", false));
 		setServiceAdmins(serviceAdmins);
+
+		String authzDeniedMode = pluginConfig.get(pluginConfig.getPropertyPrefix() + ".policy.refresh.authz.denied.mode", "continue");
+		this.failClosedOnPolicyRefreshAuthzDenied = StringUtils.equals(authzDeniedMode, "failclosed");
 
 		String  ugiPrefix = pluginConfig.getPropertyPrefix() + ".ugi";
 		boolean initUgi   = pluginConfig.getBoolean(ugiPrefix + ".initialize", false);
@@ -549,6 +553,10 @@ public class RangerBasePlugin {
 		return this.resultProcessor;
 	}
 
+	public boolean isPolicyRefreshAuthzDenied() {
+		return failClosedOnPolicyRefreshAuthzDenied && pluginContext.isPolicyRefreshAuthzDenied();
+	}
+
 	public RangerAccessResult isAccessAllowed(RangerAccessRequest request) {
 		return isAccessAllowed(request, resultProcessor);
 	}
@@ -560,12 +568,15 @@ public class RangerBasePlugin {
 	public RangerAccessResult isAccessAllowed(RangerAccessRequest request, RangerAccessResultProcessor resultProcessor) {
 		RangerAccessResult ret          = null;
 		RangerPolicyEngine policyEngine = this.policyEngine;
+		boolean            isPolicyRefreshAuthzDenied = isPolicyRefreshAuthzDenied();
 
-		if (policyEngine != null) {
+		if (isPolicyRefreshAuthzDenied) {
+			ret = getPolicyRefreshAuthzDeniedResult(request, RangerPolicy.POLICY_TYPE_ACCESS);
+		} else if (policyEngine != null) {
 			ret = policyEngine.evaluatePolicies(request, RangerPolicy.POLICY_TYPE_ACCESS, null);
 		}
 
-		if (ret != null) {
+		if (!isPolicyRefreshAuthzDenied && ret != null) {
 			for (RangerChainedPlugin chainedPlugin : chainedPlugins) {
 				if (LOG.isDebugEnabled()) {
 					LOG.debug("BasePlugin.isAccessAllowed result=[" + ret + "]");
@@ -605,12 +616,18 @@ public class RangerBasePlugin {
 	public Collection<RangerAccessResult> isAccessAllowed(Collection<RangerAccessRequest> requests, RangerAccessResultProcessor resultProcessor) {
 		Collection<RangerAccessResult> ret          = null;
 		RangerPolicyEngine             policyEngine = this.policyEngine;
+		boolean                        isPolicyRefreshAuthzDenied = isPolicyRefreshAuthzDenied();
 
-		if (policyEngine != null) {
+		if (isPolicyRefreshAuthzDenied) {
+			ret = new ArrayList<>();
+			for (RangerAccessRequest request : requests) {
+				ret.add(getPolicyRefreshAuthzDeniedResult(request, RangerPolicy.POLICY_TYPE_ACCESS));
+			}
+		} else if (policyEngine != null) {
 			ret = policyEngine.evaluatePolicies(requests, RangerPolicy.POLICY_TYPE_ACCESS, null);
 		}
 
-		if (CollectionUtils.isNotEmpty(ret)) {
+		if (!isPolicyRefreshAuthzDenied && CollectionUtils.isNotEmpty(ret)) {
 			for (RangerChainedPlugin chainedPlugin : chainedPlugins) {
 				Collection<RangerAccessResult> chainedResults = chainedPlugin.isAccessAllowed(requests);
 
@@ -646,8 +663,11 @@ public class RangerBasePlugin {
 	public RangerAccessResult evalDataMaskPolicies(RangerAccessRequest request, RangerAccessResultProcessor resultProcessor) {
 		RangerPolicyEngine policyEngine = this.policyEngine;
 		RangerAccessResult ret          = null;
+		boolean            isPolicyRefreshAuthzDenied = isPolicyRefreshAuthzDenied();
 
-		if(policyEngine != null) {
+		if (isPolicyRefreshAuthzDenied) {
+			ret = getPolicyRefreshAuthzDeniedResult(request, RangerPolicy.POLICY_TYPE_DATAMASK);
+		} else if(policyEngine != null) {
 			ret = policyEngine.evaluatePolicies(request, RangerPolicy.POLICY_TYPE_DATAMASK, resultProcessor);
 
 			if (ret != null) {
@@ -682,8 +702,11 @@ public class RangerBasePlugin {
 	public RangerAccessResult evalRowFilterPolicies(RangerAccessRequest request, RangerAccessResultProcessor resultProcessor) {
 		RangerPolicyEngine policyEngine = this.policyEngine;
 		RangerAccessResult ret          = null;
+		boolean            isPolicyRefreshAuthzDenied = isPolicyRefreshAuthzDenied();
 
-		if(policyEngine != null) {
+		if (isPolicyRefreshAuthzDenied) {
+			ret = getPolicyRefreshAuthzDeniedResult(request, RangerPolicy.POLICY_TYPE_ROWFILTER);
+		} else if(policyEngine != null) {
 			ret = policyEngine.evaluatePolicies(request, RangerPolicy.POLICY_TYPE_ROWFILTER, resultProcessor);
 
 			if (ret != null) {
@@ -711,6 +734,16 @@ public class RangerBasePlugin {
 
 			policyEngine.evaluateAuditPolicies(ret);
 		}
+
+		return ret;
+	}
+
+	private RangerAccessResult getPolicyRefreshAuthzDeniedResult(RangerAccessRequest request, int policyType) {
+		RangerAccessResult ret = new RangerAccessResult(policyType, pluginConfig.getServiceName(), getServiceDef(), request);
+
+		ret.setIsAllowed(false);
+		ret.setReason("Policy refresh authorization denied by Ranger Admin");
+		ret.setPolicyVersion(getPolicyVersion());
 
 		return ret;
 	}

--- a/agents-common/src/main/java/org/apache/ranger/plugin/util/PolicyRefresher.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/util/PolicyRefresher.java
@@ -470,8 +470,8 @@ public class PolicyRefresher extends Thread {
 				try {
 					if (!cacheFile.exists()) {
 						Files.createFile(cacheFile.toPath(), PosixFilePermissions.asFileAttribute(this.cacheFilePerms));
-						Files.setPosixFilePermissions(cacheFile.toPath(), this.cacheFilePerms);
 					}
+					cacheDirectory.secureFile(cacheFile);
 					writer = new FileWriter(cacheFile);
 					JsonUtils.objectToWriter(writer, policies);
 		        } catch (Exception excp) {
@@ -502,8 +502,8 @@ public class PolicyRefresher extends Thread {
 					try {
 						if (!backupCacheFile.exists()) {
 							Files.createFile(backupCacheFile.toPath(), PosixFilePermissions.asFileAttribute(this.cacheFilePerms));
-							Files.setPosixFilePermissions(backupCacheFile.toPath(), this.cacheFilePerms);
 						}
+						cacheDirectory.secureFile(backupCacheFile);
 					} catch (Exception excp) {
 						LOG.error("failed to save policies to cache file '" + backupCacheFile.getAbsolutePath() + "'", excp);
 					}

--- a/agents-common/src/main/java/org/apache/ranger/plugin/util/PolicyRefresher.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/util/PolicyRefresher.java
@@ -21,10 +21,8 @@ package org.apache.ranger.plugin.util;
 
 import java.io.*;
 import java.nio.file.Files;
-import java.nio.file.attribute.FileAttribute;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
-import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -32,6 +30,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.ranger.admin.client.RangerAdminClient;
+import org.apache.ranger.admin.client.RangerAdminClientAccessDeniedException;
 import org.apache.ranger.authorization.hadoop.config.RangerPluginConfig;
 import org.apache.ranger.authorization.utils.JsonUtils;
 import org.apache.ranger.plugin.policyengine.RangerPluginContext;
@@ -52,6 +51,7 @@ public class PolicyRefresher extends Thread {
 	private final long                           pollingIntervalMs;
 	private final String                         cacheFileName;
 	private final String                         cacheDir;
+	private final RangerLocalDirectory.ResolvedDirectory cacheDirectory;
 	private final Set<PosixFilePermission>      cacheFilePerms;
 	private final Set<PosixFilePermission>      cacheDirPerms;
 	private final BlockingQueue<DownloadTrigger> policyDownloadQueue = new LinkedBlockingQueue<>();
@@ -73,12 +73,17 @@ public class PolicyRefresher extends Thread {
 		this.plugIn      = plugIn;
 		this.serviceType = plugIn.getServiceType();
 		this.serviceName = plugIn.getServiceName();
-		this.cacheDir    = pluginConfig.get(propertyPrefix + ".policy.cache.dir");
 		String cacheFilePermsString = StringUtils.defaultIfEmpty(StringUtils.trim(pluginConfig.get(propertyPrefix + ".policy.cache.file.perms")), "644");
-		this.cacheFilePerms = FileUtils.parsePermissions(cacheFilePermsString);
-
 		String cacheDirPermsString = StringUtils.defaultIfEmpty(StringUtils.trim(pluginConfig.get(propertyPrefix + ".policy.cache.dir.perms")), "755");
-		this.cacheDirPerms = FileUtils.parsePermissions(cacheDirPermsString);
+		String baseCacheDir = pluginConfig.get(propertyPrefix + ".policy.cache.dir");
+		this.cacheDirectory = RangerLocalDirectory.resolve(baseCacheDir,
+				pluginConfig.get(propertyPrefix + ".policy.cache.subdir.mode", RangerLocalDirectory.SUBDIR_MODE_DISABLED),
+				FileUtils.parsePermissions(cacheDirPermsString),
+				FileUtils.parsePermissions(cacheFilePermsString));
+
+		this.cacheDir       = this.cacheDirectory.getPath();
+		this.cacheFilePerms = this.cacheDirectory.getFilePermissions();
+		this.cacheDirPerms  = this.cacheDirectory.getDirPermissions();
 
 		String appId         = StringUtils.isEmpty(plugIn.getAppId()) ? serviceType : plugIn.getAppId();
 		String cacheFilename = String.format("%s_%s.json", appId, serviceName);
@@ -91,7 +96,7 @@ public class PolicyRefresher extends Thread {
 		RangerPluginContext pluginContext  = plugIn.getPluginContext();
 		RangerAdminClient   adminClient    = pluginContext.getAdminClient();
 		this.rangerAdmin                   = (adminClient != null) ? adminClient : pluginContext.createAdminClient(pluginConfig);
-		this.rolesProvider                 = new RangerRolesProvider(getServiceType(), appId, getServiceName(), rangerAdmin,  cacheDir, pluginConfig);
+		this.rolesProvider                 = new RangerRolesProvider(getServiceType(), appId, getServiceName(), rangerAdmin, baseCacheDir, pluginConfig);
 		this.pollingIntervalMs             = pluginConfig.getLong(propertyPrefix + ".policy.pollIntervalMs", 30 * 1000L);
 
 		setName("PolicyRefresher(serviceName=" + serviceName + ")-" + getId());
@@ -240,8 +245,8 @@ public class PolicyRefresher extends Thread {
 		}
 
 		try {
-			//load policy from PolicyAdmin
 			ServicePolicies svcPolicies = loadPolicyfromPolicyAdmin();
+			plugIn.getPluginContext().setPolicyDownloadAuthzDenied(false);
 
 			if (svcPolicies == null) {
 				//if Policy fetch from Policy Admin Fails, load from cache
@@ -268,6 +273,9 @@ public class PolicyRefresher extends Thread {
 					serviceDefSetInPlugin = true;
 				}
 			}
+		} catch (RangerAdminClientAccessDeniedException ade) {
+			plugIn.getPluginContext().setPolicyDownloadAuthzDenied(true);
+            LOG.warn("PolicyRefresher(serviceName={}): policy refresh authorization denied. Access checks will fail closed if configured.", serviceName, ade);
 		} catch (RangerServiceNotFoundException snfe) {
 			if (!serviceDefSetInPlugin) {
 				disableCache();
@@ -278,6 +286,20 @@ public class PolicyRefresher extends Thread {
 			}
 		} catch (Exception excp) {
 			LOG.error("Encountered unexpected exception, ignoring..", excp);
+			if (!policiesSetInPlugin) {
+				ServicePolicies svcPolicies = loadFromCache();
+
+				if (svcPolicies != null) {
+					plugIn.setPolicies(svcPolicies);
+					policiesSetInPlugin = true;
+					serviceDefSetInPlugin = false;
+					setLastActivationTimeInMillis(System.currentTimeMillis());
+					lastKnownVersion = svcPolicies.getPolicyVersion() != null ? svcPolicies.getPolicyVersion() : -1L;
+				} else if (!serviceDefSetInPlugin) {
+					plugIn.setPolicies(null);
+					serviceDefSetInPlugin = true;
+				}
+			}
 		}
 
 		RangerPerfTracer.log(perf);
@@ -287,7 +309,7 @@ public class PolicyRefresher extends Thread {
 		}
 	}
 
-	private ServicePolicies loadPolicyfromPolicyAdmin() throws RangerServiceNotFoundException {
+	private ServicePolicies loadPolicyfromPolicyAdmin() throws Exception {
 
 		if(LOG.isDebugEnabled()) {
 			LOG.debug("==> PolicyRefresher(serviceName=" + serviceName + ").loadPolicyfromPolicyAdmin()");
@@ -323,11 +345,14 @@ public class PolicyRefresher extends Thread {
 				}
 			}
 		} catch (RangerServiceNotFoundException snfe) {
-			LOG.error("PolicyRefresher(serviceName=" + serviceName + "): failed to find service. Will clean up local cache of policies (" + lastKnownVersion + ")", snfe);
+            LOG.error("PolicyRefresher(serviceName={}): failed to find service. Will clean up local cache of policies ({})", serviceName, lastKnownVersion, snfe);
 			throw snfe;
+		} catch (RangerAdminClientAccessDeniedException ade) {
+            LOG.warn("PolicyRefresher(serviceName={}): failed to refresh policies due to authorization denial ({})", serviceName, lastKnownVersion, ade);
+			throw ade;
 		} catch (Exception excp) {
-			LOG.error("PolicyRefresher(serviceName=" + serviceName + "): failed to refresh policies. Will continue to use last known version of policies (" + lastKnownVersion + ")", excp);
-			svcPolicies = null;
+            LOG.error("PolicyRefresher(serviceName={}): failed to refresh policies. Will continue to use last known version of policies ({})", serviceName, lastKnownVersion, excp);
+			throw excp;
 		}
 
 		RangerPerfTracer.log(perf);
@@ -349,6 +374,13 @@ public class PolicyRefresher extends Thread {
 		}
 
 		File cacheFile = cacheDir == null ? null : new File(cacheDir + File.separator + cacheFileName);
+
+		try {
+			cacheDirectory.ensureDirectory();
+		} catch (Exception excp) {
+            LOG.error("failed to validate cache directory {}", cacheDir, excp);
+			return null;
+		}
 
     	if(cacheFile != null && cacheFile.isFile() && cacheFile.canRead()) {
     		Reader reader = null;
@@ -411,17 +443,15 @@ public class PolicyRefresher extends Thread {
 				String backupCacheFileName = cacheFileName + "_" + policies.getPolicyVersion();
 				String realCacheFileName = CollectionUtils.isNotEmpty(policies.getPolicyDeltas()) ? backupCacheFileName : cacheFileName;
 
-				// Create the cacheDir if it doesn't already exist
 				File cacheDirTmp = new File(realCacheDirName);
-				if (cacheDirTmp.exists()) {
-					cacheFile =  new File(realCacheDirName + File.separator + realCacheFileName);
-				} else {
-					try {
+				try {
+					cacheDirectory.ensureDirectory();
+					if (!cacheDirTmp.exists()) {
 						FileUtils.createDirectoryWithPermissions(cacheDirTmp, cacheDirPerms);
-						cacheFile =  new File(realCacheDirName + File.separator + realCacheFileName);
-					} catch (Exception ex) {
-						LOG.error("Cannot create cache directory", ex);
 					}
+					cacheFile =  new File(realCacheDirName + File.separator + realCacheFileName);
+				} catch (Exception ex) {
+					LOG.error("Cannot create cache directory", ex);
 				}
 				if (CollectionUtils.isEmpty(policies.getPolicyDeltas())) {
 					backupCacheFile = new File(realCacheDirName + File.separator + backupCacheFileName);

--- a/agents-common/src/main/java/org/apache/ranger/plugin/util/RangerLocalDirectory.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/util/RangerLocalDirectory.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ranger.plugin.util;
+
+import org.apache.ranger.audit.utils.LocalDirectoryResolver;
+
+import java.io.IOException;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.Set;
+
+public final class RangerLocalDirectory {
+	public static final String SUBDIR_MODE_DISABLED = "disabled";
+	public static final String SUBDIR_MODE_PERUSER  = "peruser";
+	public static final String SUBDIR_MODE_PERGROUP = "pergroup";
+
+	private RangerLocalDirectory() {
+	}
+
+	public static ResolvedDirectory resolve(String baseDir, String subdirMode, Set<PosixFilePermission> defaultDirPerms, Set<PosixFilePermission> defaultFilePerms) {
+		return new ResolvedDirectory(LocalDirectoryResolver.resolveLocalDirectory(baseDir, subdirMode, defaultDirPerms, defaultFilePerms));
+	}
+
+	public static final class ResolvedDirectory {
+		private final LocalDirectoryResolver.ResolvedDirectory delegate;
+
+		private ResolvedDirectory(LocalDirectoryResolver.ResolvedDirectory delegate) {
+			this.delegate = delegate;
+		}
+
+		public String getPath() {
+			return delegate.getPath();
+		}
+
+		public Set<PosixFilePermission> getDirPermissions() {
+			return delegate.getDirPermissions();
+		}
+
+		public Set<PosixFilePermission> getFilePermissions() {
+			return delegate.getFilePermissions();
+		}
+
+		public void ensureDirectory() throws IOException {
+			delegate.ensureDirectory();
+		}
+	}
+}

--- a/agents-common/src/main/java/org/apache/ranger/plugin/util/RangerLocalDirectory.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/util/RangerLocalDirectory.java
@@ -19,6 +19,7 @@ package org.apache.ranger.plugin.util;
 
 import org.apache.ranger.audit.utils.LocalDirectoryResolver;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.attribute.PosixFilePermission;
 import java.util.Set;
@@ -56,6 +57,14 @@ public final class RangerLocalDirectory {
 
 		public void ensureDirectory() throws IOException {
 			delegate.ensureDirectory();
+		}
+
+		public void ensureChildDirectory(File directory) throws IOException {
+			delegate.ensureChildDirectory(directory);
+		}
+
+		public void secureFile(File file) throws IOException {
+			delegate.secureFile(file);
 		}
 	}
 }

--- a/agents-common/src/main/java/org/apache/ranger/plugin/util/RangerRolesProvider.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/util/RangerRolesProvider.java
@@ -330,8 +330,8 @@ public class RangerRolesProvider {
 				try {
 					if (!cacheFile.exists()) {
 						Files.createFile(cacheFile.toPath(), PosixFilePermissions.asFileAttribute(this.cacheFilePerms));
-						Files.setPosixFilePermissions(cacheFile.toPath(), this.cacheFilePerms);
 					}
+					cacheDirectory.secureFile(cacheFile);
 					writer = new FileWriter(cacheFile);
 					JsonUtils.objectToWriter(writer, roles);
 		        } catch (Exception excp) {

--- a/agents-common/src/main/java/org/apache/ranger/plugin/util/RangerRolesProvider.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/util/RangerRolesProvider.java
@@ -55,7 +55,6 @@ public class RangerRolesProvider {
 	private final String            cacheDir;
 	private final RangerLocalDirectory.ResolvedDirectory cacheDirectory;
 	private final Set<PosixFilePermission> cacheFilePerms;
-	private final Set<PosixFilePermission>      cacheDirPerms;
 	private final boolean           disableCacheIfServiceNotFound;
 
 	private long	lastActivationTimeInMillis;
@@ -93,7 +92,6 @@ public class RangerRolesProvider {
 		this.cacheFileName  = cacheFilename;
 		this.cacheDir       = this.cacheDirectory.getPath();
 		this.cacheFilePerms = this.cacheDirectory.getFilePermissions();
-		this.cacheDirPerms  = this.cacheDirectory.getDirPermissions();
 
 		if (LOG.isDebugEnabled()) {
 			LOG.debug("<== RangerRolesProvider(serviceName=" + serviceName + ").RangerRolesProvider()");

--- a/agents-common/src/main/java/org/apache/ranger/plugin/util/RangerRolesProvider.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/util/RangerRolesProvider.java
@@ -21,6 +21,7 @@ package org.apache.ranger.plugin.util;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.ranger.admin.client.RangerAdminClient;
+import org.apache.ranger.admin.client.RangerAdminClientAccessDeniedException;
 import org.apache.ranger.authorization.hadoop.config.RangerPluginConfig;
 import org.apache.ranger.authorization.utils.JsonUtils;
 import org.apache.ranger.plugin.service.RangerBasePlugin;
@@ -52,6 +53,7 @@ public class RangerRolesProvider {
 	private final String            cacheFileName;
 	private final String			cacheFileNamePrefix;
 	private final String            cacheDir;
+	private final RangerLocalDirectory.ResolvedDirectory cacheDirectory;
 	private final Set<PosixFilePermission> cacheFilePerms;
 	private final Set<PosixFilePermission>      cacheDirPerms;
 	private final boolean           disableCacheIfServiceNotFound;
@@ -80,15 +82,18 @@ public class RangerRolesProvider {
 		cacheFilename = cacheFilename.replace(File.separatorChar, '_');
 		cacheFilename = cacheFilename.replace(File.pathSeparatorChar, '_');
 
-		this.cacheFileName = cacheFilename;
-		this.cacheDir = cacheDir;
 		String propertyPrefix = config.getPropertyPrefix();
 		disableCacheIfServiceNotFound = config.getBoolean(propertyPrefix + ".disable.cache.if.servicenotfound", true);
 		String cacheFilePermsString = StringUtils.defaultIfEmpty(StringUtils.trim(config.get(propertyPrefix + ".policy.cache.file.perms")), "644");
-		this.cacheFilePerms = FileUtils.parsePermissions(cacheFilePermsString);
-
 		String cacheDirPermsString = StringUtils.defaultIfEmpty(StringUtils.trim(config.get(propertyPrefix + ".policy.cache.dir.perms")), "755");
-		this.cacheDirPerms = FileUtils.parsePermissions(cacheDirPermsString);
+		this.cacheDirectory = RangerLocalDirectory.resolve(cacheDir,
+				config.get(propertyPrefix + ".policy.cache.subdir.mode", RangerLocalDirectory.SUBDIR_MODE_DISABLED),
+				FileUtils.parsePermissions(cacheDirPermsString),
+				FileUtils.parsePermissions(cacheFilePermsString));
+		this.cacheFileName  = cacheFilename;
+		this.cacheDir       = this.cacheDirectory.getPath();
+		this.cacheFilePerms = this.cacheDirectory.getFilePermissions();
+		this.cacheDirPerms  = this.cacheDirectory.getDirPermissions();
 
 		if (LOG.isDebugEnabled()) {
 			LOG.debug("<== RangerRolesProvider(serviceName=" + serviceName + ").RangerRolesProvider()");
@@ -119,8 +124,8 @@ public class RangerRolesProvider {
 		}
 
 		try {
-			//load userGroupRoles from ranger admin
 			RangerRoles roles = loadUserGroupRolesFromAdmin();
+			plugIn.getPluginContext().setRoleDownloadAuthzDenied(false);
 
 			if (roles == null) {
 				//if userGroupRoles fetch from ranger Admin Fails, load from cache
@@ -146,6 +151,9 @@ public class RangerRolesProvider {
 					serviceDefSetInPlugin = true;
 				}
 			}
+		} catch (RangerAdminClientAccessDeniedException ade) {
+			plugIn.getPluginContext().setRoleDownloadAuthzDenied(true);
+            LOG.warn("RangerRolesProvider(serviceName={}): role refresh authorization denied. Access checks will fail closed if configured.", serviceName, ade);
 		} catch (RangerServiceNotFoundException snfe) {
 			if (disableCacheIfServiceNotFound) {
 				disableCache();
@@ -156,6 +164,19 @@ public class RangerRolesProvider {
 			}
 		} catch (Exception excp) {
 			LOG.error("Encountered unexpected exception, ignoring..", excp);
+			if (!rangerUserGroupRolesSetInPlugin) {
+				RangerRoles roles = loadUserGroupRolesFromCache();
+
+				if (roles != null) {
+					plugIn.setRoles(roles);
+					rangerUserGroupRolesSetInPlugin = true;
+					setLastActivationTimeInMillis(System.currentTimeMillis());
+					lastKnownRoleVersion = roles.getRoleVersion() != null ? roles.getRoleVersion() : -1;
+				} else if (!serviceDefSetInPlugin) {
+					plugIn.setRoles(null);
+					serviceDefSetInPlugin = true;
+				}
+			}
 		}
 
 		RangerPerfTracer.log(perf);
@@ -165,7 +186,7 @@ public class RangerRolesProvider {
 		}
 	}
 
-	private RangerRoles loadUserGroupRolesFromAdmin() throws RangerServiceNotFoundException {
+	private RangerRoles loadUserGroupRolesFromAdmin() throws Exception {
 
 		if(LOG.isDebugEnabled()) {
 			LOG.debug("==> RangerRolesProvider(serviceName=" + serviceName + ").loadUserGroupRolesFromAdmin()");
@@ -196,9 +217,12 @@ public class RangerRolesProvider {
 		} catch (RangerServiceNotFoundException snfe) {
 			LOG.error("RangerRolesProvider(serviceName=" + serviceName + "): failed to find service. Will clean up local cache of roles (" + lastKnownRoleVersion + ")", snfe);
 			throw snfe;
+		} catch (RangerAdminClientAccessDeniedException ade) {
+            LOG.warn("RangerRolesProvider(serviceName={}): failed to refresh roles due to authorization denial (lastKnownRoleVersion={})", serviceName, lastKnownRoleVersion, ade);
+			throw ade;
 		} catch (Exception excp) {
-			LOG.error("RangerRolesProvider(serviceName=" + serviceName + "): failed to refresh roles. Will continue to use last known version of roles (" + "lastKnowRoleVersion= " + lastKnownRoleVersion, excp);
-			roles = null;
+            LOG.error("RangerRolesProvider(serviceName={}): failed to refresh roles. Will continue to use last known version of roles (lastKnowRoleVersion= {}", serviceName, lastKnownRoleVersion, excp);
+			throw excp;
 		}
 
 		RangerPerfTracer.log(perf);
@@ -219,6 +243,13 @@ public class RangerRolesProvider {
 		}
 
 		File cacheFile = cacheDir == null ? null : new File(cacheDir + File.separator + cacheFileName);
+
+		try {
+			cacheDirectory.ensureDirectory();
+		} catch (Exception excp) {
+            LOG.error("failed to validate roles cache directory {}", cacheDir, excp);
+			return null;
+		}
 
 		if (cacheFile != null && cacheFile.isFile() && cacheFile.canRead()) {
 			Reader reader = null;
@@ -280,17 +311,11 @@ public class RangerRolesProvider {
 		if(roles != null) {
 			File cacheFile = null;
 			if (cacheDir != null) {
-				// Create the cacheDir if it doesn't already exist
-				File cacheDirTmp = new File(cacheDir);
-				if (cacheDirTmp.exists()) {
+				try {
+					cacheDirectory.ensureDirectory();
 					cacheFile =  new File(cacheDir + File.separator + cacheFileName);
-				} else {
-					try {
-						FileUtils.createDirectoryWithPermissions(cacheDirTmp, cacheDirPerms);
-						cacheFile =  new File(cacheDir + File.separator + cacheFileName);
-					} catch (Exception ex) {
-						LOG.error("Cannot create cache directory", ex);
-					}
+				} catch (Exception ex) {
+					LOG.error("Cannot create cache directory", ex);
 				}
 			}
 

--- a/agents-common/src/main/resources/service-defs/ranger-servicedef-nestedstructure.json
+++ b/agents-common/src/main/resources/service-defs/ranger-servicedef-nestedstructure.json
@@ -9,7 +9,8 @@
   },
   "configs": [
     { "itemId": 1, "name": "commonNameForCertificate",   "type": "string", "mandatory": false },
-    { "itemId": 2, "name": "policy.download.auth.users", "type": "string", "mandatory": false }
+    { "itemId": 2, "name": "policy.download.auth.users",  "type": "string", "mandatory": false },
+    { "itemId": 3, "name": "policy.download.auth.groups", "type": "string", "mandatory": false }
   ],
   "resources": [
     {

--- a/agents-common/src/test/java/org/apache/ranger/plugin/service/TestRangerBasePlugin.java
+++ b/agents-common/src/test/java/org/apache/ranger/plugin/service/TestRangerBasePlugin.java
@@ -60,6 +60,35 @@ public class TestRangerBasePlugin {
         runTestsFromResourceFile("/plugin/test_base_plugin_hive.json");
     }
 
+    @Test
+    public void testPolicyRefreshAuthzDeniedFailsClosedWhenConfigured() {
+        RangerBasePluginTestCase testCase = readTestCase(new InputStreamReader(this.getClass().getResourceAsStream("/plugin/test_base_plugin_hive.json")));
+        TestData                 test     = testCase.tests.get(0);
+        RangerPluginConfig       config   = new RangerPluginConfig(testCase.policies.getServiceDef().getName(), testCase.policies.getServiceName(), "hive", "cl1", "on-prem", peOptions);
+
+        config.set(config.getPropertyPrefix() + ".policy.refresh.authz.denied.mode", "failclosed");
+
+        RangerBasePlugin plugin = new RangerBasePlugin(config, testCase.policies, testCase.tags, testCase.roles, testCase.userStore);
+
+        RangerAccessResult allowedResult = plugin.isAccessAllowed(test.request);
+        assertNotNull(allowedResult);
+        assertTrue(allowedResult.getIsAllowed());
+
+        plugin.getPluginContext().setPolicyDownloadAuthzDenied(true);
+
+        RangerAccessResult deniedResult = plugin.isAccessAllowed(test.request);
+        assertNotNull(deniedResult);
+        assertFalse(deniedResult.getIsAllowed());
+        assertTrue(deniedResult.getIsAccessDetermined());
+        assertEquals("Policy refresh authorization denied by Ranger Admin", deniedResult.getReason());
+
+        plugin.getPluginContext().setPolicyDownloadAuthzDenied(false);
+
+        RangerAccessResult restoredResult = plugin.isAccessAllowed(test.request);
+        assertNotNull(restoredResult);
+        assertTrue(restoredResult.getIsAllowed());
+    }
+
     private void runTestsFromResourceFile(String resourceFile) {
         InputStream       inStream = this.getClass().getResourceAsStream(resourceFile);
         InputStreamReader reader   = new InputStreamReader(inStream);

--- a/agents-common/src/test/java/org/apache/ranger/plugin/util/RangerLocalDirectoryTest.java
+++ b/agents-common/src/test/java/org/apache/ranger/plugin/util/RangerLocalDirectoryTest.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.plugin.util;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Comparator;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class RangerLocalDirectoryTest {
+	@Test
+	public void testPerUserDirectoryUsesPrivatePermissions() throws Exception {
+		Path baseDir = Files.createTempDirectory("ranger-policy-cache");
+
+		try {
+			Files.setPosixFilePermissions(baseDir, PosixFilePermissions.fromString("rwxr-xr-x"));
+			RangerLocalDirectory.ResolvedDirectory directory = RangerLocalDirectory.resolve(baseDir.toString(),
+					RangerLocalDirectory.SUBDIR_MODE_PERUSER,
+					FileUtils.parsePermissions("755"),
+					FileUtils.parsePermissions("644"));
+
+			directory.ensureDirectory();
+
+			Path resolvedPath = Paths.get(directory.getPath());
+			assertTrue(Files.isDirectory(resolvedPath));
+			assertEquals(PosixFilePermissions.fromString("rwxr-xr-x"), Files.getPosixFilePermissions(baseDir));
+			assertEquals(PosixFilePermissions.fromString("rwx------"), Files.getPosixFilePermissions(resolvedPath));
+			assertEquals(PosixFilePermissions.fromString("rw-------"), directory.getFilePermissions());
+		} finally {
+			deleteRecursively(baseDir);
+		}
+	}
+
+	@Test
+	public void testPerGroupDirectoryUsesGroupPermissions() throws Exception {
+		Path baseDir = Files.createTempDirectory("ranger-policy-cache");
+
+		try {
+			Files.setPosixFilePermissions(baseDir, PosixFilePermissions.fromString("rwxr-xr-x"));
+			RangerLocalDirectory.ResolvedDirectory directory = RangerLocalDirectory.resolve(baseDir.toString(),
+					RangerLocalDirectory.SUBDIR_MODE_PERGROUP,
+					FileUtils.parsePermissions("755"),
+					FileUtils.parsePermissions("644"));
+
+			directory.ensureDirectory();
+
+			Path resolvedPath = Paths.get(directory.getPath());
+			assertTrue(Files.isDirectory(resolvedPath));
+			assertEquals(PosixFilePermissions.fromString("rwxr-xr-x"), Files.getPosixFilePermissions(baseDir));
+			assertEquals(PosixFilePermissions.fromString("rwxrwx---"), Files.getPosixFilePermissions(resolvedPath));
+			assertEquals(PosixFilePermissions.fromString("rw-rw----"), directory.getFilePermissions());
+		} finally {
+			deleteRecursively(baseDir);
+		}
+	}
+
+	@Test(expected = IOException.class)
+	public void testUnsafeExistingDirectoryPermissionsAreRejected() throws Exception {
+		Path baseDir = Files.createTempDirectory("ranger-policy-cache");
+
+		try {
+			Files.setPosixFilePermissions(baseDir, PosixFilePermissions.fromString("rwxr-xr-x"));
+			RangerLocalDirectory.ResolvedDirectory directory = RangerLocalDirectory.resolve(baseDir.toString(),
+					RangerLocalDirectory.SUBDIR_MODE_PERUSER,
+					FileUtils.parsePermissions("755"),
+					FileUtils.parsePermissions("644"));
+			Path resolvedPath = Paths.get(directory.getPath());
+
+			Files.createDirectories(resolvedPath);
+			Files.setPosixFilePermissions(resolvedPath, PosixFilePermissions.fromString("rwxr-xr-x"));
+
+			directory.ensureDirectory();
+		} finally {
+			deleteRecursively(baseDir);
+		}
+	}
+
+	@Test
+	public void testPerUserDirectoryRequiresExistingBaseDirectory() throws Exception {
+		Path tempDir = Files.createTempDirectory("ranger-policy-cache-parent");
+
+		try {
+			Path baseDir = tempDir.resolve("policy-cache");
+			RangerLocalDirectory.ResolvedDirectory directory = RangerLocalDirectory.resolve(baseDir.toString(),
+					RangerLocalDirectory.SUBDIR_MODE_PERUSER,
+					FileUtils.parsePermissions("755"),
+					FileUtils.parsePermissions("644"));
+
+			try {
+				directory.ensureDirectory();
+				fail("Expected missing base directory to be rejected");
+			} catch (IOException exception) {
+				assertTrue(exception.getMessage().contains("Base local directory does not exist"));
+			}
+
+			assertFalse(Files.exists(baseDir));
+		} finally {
+			deleteRecursively(tempDir);
+		}
+	}
+
+	@Test
+	public void testPerUserDirectoryRejectsUnsafeBasePermissions() throws Exception {
+		Path baseDir = Files.createTempDirectory("ranger-policy-cache");
+
+		try {
+			RangerLocalDirectory.ResolvedDirectory directory = RangerLocalDirectory.resolve(baseDir.toString(),
+					RangerLocalDirectory.SUBDIR_MODE_PERUSER,
+					FileUtils.parsePermissions("755"),
+					FileUtils.parsePermissions("644"));
+			Path resolvedPath = Paths.get(directory.getPath());
+
+			try {
+				directory.ensureDirectory();
+				fail("Expected unsafe base directory permissions to be rejected");
+			} catch (IOException exception) {
+				assertTrue(exception.getMessage().contains("Unsafe permissions on base local directory"));
+			}
+
+			assertFalse(Files.exists(resolvedPath));
+		} finally {
+			deleteRecursively(baseDir);
+		}
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testUnknownSubdirModeIsRejected() {
+		RangerLocalDirectory.resolve("/tmp/ranger-cache", "unknown", FileUtils.parsePermissions("755"), FileUtils.parsePermissions("644"));
+	}
+
+	private static void deleteRecursively(Path path) throws IOException {
+		if (path == null || !Files.exists(path)) {
+			return;
+		}
+
+		try (java.util.stream.Stream<Path> paths = Files.walk(path)) {
+			paths.sorted(Comparator.reverseOrder()).forEach(currentPath -> {
+				try {
+					Files.deleteIfExists(currentPath);
+				} catch (IOException ignored) {
+				}
+			});
+		}
+	}
+}

--- a/agents-common/src/test/java/org/apache/ranger/plugin/util/RangerLocalDirectoryTest.java
+++ b/agents-common/src/test/java/org/apache/ranger/plugin/util/RangerLocalDirectoryTest.java
@@ -19,13 +19,16 @@
 
 package org.apache.ranger.plugin.util;
 
+import org.apache.hadoop.security.UserGroupInformation;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.attribute.GroupPrincipal;
 import java.nio.file.attribute.PosixFilePermissions;
+import java.security.PrivilegedExceptionAction;
 import java.util.Comparator;
 
 import static org.junit.Assert.assertEquals;
@@ -58,6 +61,31 @@ public class RangerLocalDirectoryTest {
 	}
 
 	@Test
+	public void testPerUserDirectoryNamedByUgiUserButOwnedByProcessUser() throws Exception {
+		Path baseDir = Files.createTempDirectory("ranger-policy-cache");
+
+		try {
+			Files.setPosixFilePermissions(baseDir, PosixFilePermissions.fromString("rwxr-xr-x"));
+			UserGroupInformation user = UserGroupInformation.createRemoteUser("spark_user_test");
+			RangerLocalDirectory.ResolvedDirectory directory = user.doAs((PrivilegedExceptionAction<RangerLocalDirectory.ResolvedDirectory>) () ->
+					RangerLocalDirectory.resolve(baseDir.toString(),
+							RangerLocalDirectory.SUBDIR_MODE_PERUSER,
+							FileUtils.parsePermissions("755"),
+							FileUtils.parsePermissions("644")));
+
+			directory.ensureDirectory();
+
+			Path resolvedPath = Paths.get(directory.getPath());
+			assertEquals("spark_user_test", resolvedPath.getFileName().toString());
+			assertTrue(Files.isDirectory(resolvedPath));
+			assertEquals(System.getProperty("user.name"), Files.getOwner(resolvedPath).getName());
+			assertEquals(PosixFilePermissions.fromString("rwx------"), Files.getPosixFilePermissions(resolvedPath));
+		} finally {
+			deleteRecursively(baseDir);
+		}
+	}
+
+	@Test
 	public void testPerGroupDirectoryUsesGroupPermissions() throws Exception {
 		Path baseDir = Files.createTempDirectory("ranger-policy-cache");
 
@@ -75,6 +103,56 @@ public class RangerLocalDirectoryTest {
 			assertEquals(PosixFilePermissions.fromString("rwxr-xr-x"), Files.getPosixFilePermissions(baseDir));
 			assertEquals(PosixFilePermissions.fromString("rwxrwx---"), Files.getPosixFilePermissions(resolvedPath));
 			assertEquals(PosixFilePermissions.fromString("rw-rw----"), directory.getFilePermissions());
+		} finally {
+			deleteRecursively(baseDir);
+		}
+	}
+
+	@Test
+	public void testPerGroupFileAndChildDirectoryUseGroupPermissions() throws Exception {
+		Path baseDir = Files.createTempDirectory("ranger-policy-cache");
+
+		try {
+			Files.setPosixFilePermissions(baseDir, PosixFilePermissions.fromString("rwxr-xr-x"));
+			RangerLocalDirectory.ResolvedDirectory directory = RangerLocalDirectory.resolve(baseDir.toString(),
+					RangerLocalDirectory.SUBDIR_MODE_PERGROUP,
+					FileUtils.parsePermissions("755"),
+					FileUtils.parsePermissions("644"));
+
+			directory.ensureDirectory();
+
+			Path resolvedPath = Paths.get(directory.getPath());
+			Path archivePath  = resolvedPath.resolve("archive");
+			Path cacheFile    = resolvedPath.resolve("policy-cache.json");
+
+			directory.ensureChildDirectory(archivePath.toFile());
+			Files.createFile(cacheFile);
+			directory.secureFile(cacheFile.toFile());
+
+			GroupPrincipal expectedGroup = Files.readAttributes(resolvedPath, java.nio.file.attribute.PosixFileAttributes.class).group();
+
+			assertEquals(PosixFilePermissions.fromString("rwxrwx---"), Files.getPosixFilePermissions(archivePath));
+			assertEquals(PosixFilePermissions.fromString("rw-rw----"), Files.getPosixFilePermissions(cacheFile));
+			assertEquals(expectedGroup.getName(), Files.readAttributes(archivePath, java.nio.file.attribute.PosixFileAttributes.class).group().getName());
+			assertEquals(expectedGroup.getName(), Files.readAttributes(cacheFile, java.nio.file.attribute.PosixFileAttributes.class).group().getName());
+		} finally {
+			deleteRecursively(baseDir);
+		}
+	}
+
+	@Test
+	public void testPerGroupDirectoryPrefersNonPrivateUserGroup() throws Exception {
+		Path baseDir = Files.createTempDirectory("ranger-policy-cache");
+
+		try {
+			UserGroupInformation user = UserGroupInformation.createUserForTesting("spark_user2", new String[] {"spark_user2", "spark_group"});
+			RangerLocalDirectory.ResolvedDirectory directory = user.doAs((PrivilegedExceptionAction<RangerLocalDirectory.ResolvedDirectory>) () ->
+					RangerLocalDirectory.resolve(baseDir.toString(),
+							RangerLocalDirectory.SUBDIR_MODE_PERGROUP,
+							FileUtils.parsePermissions("755"),
+							FileUtils.parsePermissions("644")));
+
+			assertEquals("spark_group", Paths.get(directory.getPath()).getFileName().toString());
 		} finally {
 			deleteRecursively(baseDir);
 		}

--- a/plugin-nestedstructure/src/test/resources/servicedef-nestedstructure.json
+++ b/plugin-nestedstructure/src/test/resources/servicedef-nestedstructure.json
@@ -9,7 +9,8 @@
   },
   "configs": [
     { "itemId": 1, "name": "commonNameForCertificate",   "type": "string", "mandatory": false },
-    { "itemId": 2, "name": "policy.download.auth.users", "type": "string", "mandatory": false }
+    { "itemId": 2, "name": "policy.download.auth.users",  "type": "string", "mandatory": false },
+    { "itemId": 3, "name": "policy.download.auth.groups", "type": "string", "mandatory": false }
   ],
   "resources": [
     {

--- a/pom.xml
+++ b/pom.xml
@@ -889,6 +889,7 @@
         <profile>
             <id>ranger-examples</id>
             <modules>
+                <module>agents-audit</module>
                 <module>agents-common</module>
                 <module>agents-cred</module>
                 <module>intg</module>
@@ -898,6 +899,7 @@
         <profile>
             <id>ranger-admin</id>
             <modules>
+                <module>agents-audit</module>
                 <module>agents-common</module>
                 <module>security-admin</module>
                 <module>ugsync-util</module>

--- a/security-admin/db/mysql/optimized/current/ranger_core_db_mysql.sql
+++ b/security-admin/db/mysql/optimized/current/ranger_core_db_mysql.sql
@@ -1903,4 +1903,5 @@ INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active
 INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('J10061',UTC_TIMESTAMP(),'Ranger 2.5.0',UTC_TIMESTAMP(),'localhost','Y');
 INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('J10062',UTC_TIMESTAMP(),'Ranger 2.5.0',UTC_TIMESTAMP(),'localhost','Y');
 INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('J10063',UTC_TIMESTAMP(),'Ranger 2.5.0',UTC_TIMESTAMP(),'localhost','Y');
+INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('J10064',UTC_TIMESTAMP(),'Ranger 2.5.0',UTC_TIMESTAMP(),'localhost','Y');
 INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('JAVA_PATCHES',UTC_TIMESTAMP(),'Ranger 1.0.0',UTC_TIMESTAMP(),'localhost','Y');

--- a/security-admin/db/oracle/optimized/current/ranger_core_db_oracle.sql
+++ b/security-admin/db/oracle/optimized/current/ranger_core_db_oracle.sql
@@ -2097,5 +2097,6 @@ INSERT INTO x_db_version_h (id,version,inst_at,inst_by,updated_at,updated_by,act
 INSERT INTO x_db_version_h (id,version,inst_at,inst_by,updated_at,updated_by,active) VALUES (X_DB_VERSION_H_SEQ.nextval,'J10061',sys_extract_utc(systimestamp),'Ranger 2.5.0',sys_extract_utc(systimestamp),'localhost','Y');
 INSERT INTO x_db_version_h (id,version,inst_at,inst_by,updated_at,updated_by,active) VALUES (X_DB_VERSION_H_SEQ.nextval,'J10062',sys_extract_utc(systimestamp),'Ranger 2.5.0',sys_extract_utc(systimestamp),'localhost','Y');
 INSERT INTO x_db_version_h (id,version,inst_at,inst_by,updated_at,updated_by,active) VALUES (X_DB_VERSION_H_SEQ.nextval,'J10063',sys_extract_utc(systimestamp),'Ranger 2.5.0',sys_extract_utc(systimestamp),'localhost','Y');
+INSERT INTO x_db_version_h (id,version,inst_at,inst_by,updated_at,updated_by,active) VALUES (X_DB_VERSION_H_SEQ.nextval,'J10064',sys_extract_utc(systimestamp),'Ranger 2.5.0',sys_extract_utc(systimestamp),'localhost','Y');
 INSERT INTO x_db_version_h (id,version,inst_at,inst_by,updated_at,updated_by,active) VALUES (X_DB_VERSION_H_SEQ.nextval,'JAVA_PATCHES',sys_extract_utc(systimestamp),'Ranger 1.0.0',sys_extract_utc(systimestamp),'localhost','Y');
 commit;

--- a/security-admin/db/postgres/optimized/current/ranger_core_db_postgres.sql
+++ b/security-admin/db/postgres/optimized/current/ranger_core_db_postgres.sql
@@ -2046,4 +2046,5 @@ INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active
 INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('J10061',current_timestamp,'Ranger 2.5.0',current_timestamp,'localhost','Y');
 INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('J10062',current_timestamp,'Ranger 2.5.0',current_timestamp,'localhost','Y');
 INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('J10063',current_timestamp,'Ranger 2.5.0',current_timestamp,'localhost','Y');
+INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('J10064',current_timestamp,'Ranger 2.5.0',current_timestamp,'localhost','Y');
 INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('JAVA_PATCHES',current_timestamp,'Ranger 1.0.0',current_timestamp,'localhost','Y');

--- a/security-admin/db/sqlanywhere/optimized/current/ranger_core_db_sqlanywhere.sql
+++ b/security-admin/db/sqlanywhere/optimized/current/ranger_core_db_sqlanywhere.sql
@@ -2472,6 +2472,8 @@ INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active
 GO
 INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('J10063',CURRENT_TIMESTAMP,'Ranger 2.5.0',CURRENT_TIMESTAMP,'localhost','Y');
 GO
+INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('J10064',CURRENT_TIMESTAMP,'Ranger 2.5.0',CURRENT_TIMESTAMP,'localhost','Y');
+GO
 INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('JAVA_PATCHES',CURRENT_TIMESTAMP,'Ranger 1.0.0',CURRENT_TIMESTAMP,'localhost','Y');
 GO
 exit

--- a/security-admin/db/sqlserver/optimized/current/ranger_core_db_sqlserver.sql
+++ b/security-admin/db/sqlserver/optimized/current/ranger_core_db_sqlserver.sql
@@ -4265,5 +4265,6 @@ INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active
 INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('J10061',CURRENT_TIMESTAMP,'Ranger 2.5.0',CURRENT_TIMESTAMP,'localhost','Y');
 INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('J10062',CURRENT_TIMESTAMP,'Ranger 2.5.0',CURRENT_TIMESTAMP,'localhost','Y');
 INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('J10063',CURRENT_TIMESTAMP,'Ranger 2.5.0',CURRENT_TIMESTAMP,'localhost','Y');
+INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('J10064',CURRENT_TIMESTAMP,'Ranger 2.5.0',CURRENT_TIMESTAMP,'localhost','Y');
 INSERT INTO x_db_version_h (version,inst_at,inst_by,updated_at,updated_by,active) VALUES ('JAVA_PATCHES',CURRENT_TIMESTAMP,'Ranger 1.0.0',CURRENT_TIMESTAMP,'localhost','Y');
 GO

--- a/security-admin/src/main/java/org/apache/ranger/biz/RangerBizUtil.java
+++ b/security-admin/src/main/java/org/apache/ranger/biz/RangerBizUtil.java
@@ -26,6 +26,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -1410,6 +1411,67 @@ public class RangerBizUtil {
 			}
 		}
 		return false;
+	}
+
+	public boolean isUserInAllowedGroup(RangerService rangerService, String cfgNameAllowedGroups) {
+		String user = null;
+		UserSessionBase userSession = ContextUtil.getCurrentUserSession();
+		if (userSession != null) {
+			user = userSession.getLoginId();
+		}
+
+		if (StringUtils.isNotBlank(user)) {
+			return isAnyGroupInConfigParameter(rangerService, cfgNameAllowedGroups, getGroupsForLoginId(user));
+		}
+
+		return false;
+	}
+
+	private Set<String> getGroupsForLoginId(String loginId) {
+		Set<String> groups = new LinkedHashSet<>();
+
+		for (String userName : getUserNameCandidates(loginId)) {
+			if (StringUtils.isBlank(userName)) {
+				continue;
+			}
+
+			XXUser xUser = daoManager != null && daoManager.getXXUser() != null ? daoManager.getXXUser().findByUserName(userName) : null;
+
+			if (xUser != null && daoManager.getXXGroup() != null) {
+				List<XXGroup> userGroups = daoManager.getXXGroup().findByUserId(xUser.getId());
+
+				if (CollectionUtils.isNotEmpty(userGroups)) {
+					for (XXGroup userGroup : userGroups) {
+						if (userGroup != null && StringUtils.isNotBlank(userGroup.getName())) {
+							groups.add(userGroup.getName());
+						}
+					}
+				}
+			}
+
+			if (userMgr != null && userMgr.xUserMgr != null) {
+				Set<String> xUserMgrGroups = userMgr.xUserMgr.getGroupsForUser(userName);
+
+				if (CollectionUtils.isNotEmpty(xUserMgrGroups)) {
+					groups.addAll(xUserMgrGroups);
+				}
+			}
+		}
+
+		return groups;
+	}
+
+	private Set<String> getUserNameCandidates(String loginId) {
+		Set<String> ret = new LinkedHashSet<>();
+		String      userName = StringUtils.trim(loginId);
+
+		if (StringUtils.isNotBlank(userName)) {
+			ret.add(userName);
+			ret.add(StringUtils.substringBefore(userName, "@"));
+			ret.add(StringUtils.substringBefore(StringUtils.substringBefore(userName, "@"), "/"));
+		}
+
+		return ret;
 	}
 
 	public boolean isUserAllowedForGrantRevoke(RangerService rangerService, String userName) {

--- a/security-admin/src/main/java/org/apache/ranger/patch/PatchForNestedstructureServiceDefUpdate_J10064.java
+++ b/security-admin/src/main/java/org/apache/ranger/patch/PatchForNestedstructureServiceDefUpdate_J10064.java
@@ -1,0 +1,193 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.ranger.patch;
+
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.ranger.biz.ServiceDBStore;
+import org.apache.ranger.common.RangerValidatorFactory;
+import org.apache.ranger.plugin.model.RangerServiceDef;
+import org.apache.ranger.plugin.model.RangerServiceDef.RangerServiceConfigDef;
+import org.apache.ranger.plugin.model.validation.RangerServiceDefValidator;
+import org.apache.ranger.plugin.model.validation.RangerValidator.Action;
+import org.apache.ranger.plugin.store.EmbeddedServiceDefsUtil;
+import org.apache.ranger.util.CLIUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class PatchForNestedstructureServiceDefUpdate_J10064 extends BaseLoader {
+    private static final Logger logger = LoggerFactory.getLogger(PatchForNestedstructureServiceDefUpdate_J10064.class);
+
+    private static final String SERVICE_DEF_NAME            = EmbeddedServiceDefsUtil.EMBEDDED_SERVICEDEF_NESTEDSTRUCTURE_NAME;
+    private static final String POLICY_DOWNLOAD_AUTH_GROUPS = "policy.download.auth.groups";
+
+    @Autowired
+    ServiceDBStore svcDBStore;
+
+    @Autowired
+    private RangerValidatorFactory validatorFactory;
+
+    public static void main(String[] args) {
+        logger.info("main()");
+
+        try {
+            PatchForNestedstructureServiceDefUpdate_J10064 loader = (PatchForNestedstructureServiceDefUpdate_J10064) CLIUtil.getBean(PatchForNestedstructureServiceDefUpdate_J10064.class);
+
+            loader.init();
+
+            while (loader.isMoreToProcess()) {
+                loader.load();
+            }
+
+            logger.info("Load complete. Exiting!!!");
+
+            System.exit(0);
+        } catch (Exception e) {
+            logger.error("Error loading", e);
+
+            System.exit(1);
+        }
+    }
+
+    @Override
+    public void init() throws Exception {
+        // Do Nothing
+    }
+
+    @Override
+    public void execLoad() {
+        logger.info("==> PatchForNestedstructureServiceDefUpdate_J10064.execLoad()");
+
+        try {
+            updateNestedstructureServiceDef();
+        } catch (Exception e) {
+            logger.error("PatchForNestedstructureServiceDefUpdate_J10064.execLoad(): failed", e);
+            System.exit(1);
+        }
+
+        logger.info("<== PatchForNestedstructureServiceDefUpdate_J10064.execLoad()");
+    }
+
+    @Override
+    public void printStats() {
+        logger.info("PatchForNestedstructureServiceDefUpdate_J10064");
+    }
+
+    private void updateNestedstructureServiceDef() throws Exception {
+        logger.info("==> PatchForNestedstructureServiceDefUpdate_J10064.updateNestedstructureServiceDef()");
+
+        RangerServiceDef embeddedServiceDef = EmbeddedServiceDefsUtil.instance().getEmbeddedServiceDef(SERVICE_DEF_NAME);
+
+        if (embeddedServiceDef == null) {
+            throw new IllegalStateException("Embedded service-def does not exist: " + SERVICE_DEF_NAME);
+        }
+
+        RangerServiceConfigDef embeddedConfig = findConfigByName(embeddedServiceDef.getConfigs(), POLICY_DOWNLOAD_AUTH_GROUPS);
+
+        if (embeddedConfig == null) {
+            throw new IllegalStateException("Embedded service-def " + SERVICE_DEF_NAME + " does not contain config: " + POLICY_DOWNLOAD_AUTH_GROUPS);
+        }
+
+        RangerServiceDef dbServiceDef = svcDBStore.getServiceDefByName(SERVICE_DEF_NAME);
+
+        if (dbServiceDef == null) {
+            logger.info("Service-def [{}] does not exist in Ranger DB. Skipping.", SERVICE_DEF_NAME);
+            return;
+        }
+
+        if (findConfigByName(dbServiceDef.getConfigs(), POLICY_DOWNLOAD_AUTH_GROUPS) != null) {
+            logger.info("Config [{}] already exists in service-def [{}]. Skipping.", POLICY_DOWNLOAD_AUTH_GROUPS, SERVICE_DEF_NAME);
+            return;
+        }
+
+        List<RangerServiceConfigDef> configs = CollectionUtils.isEmpty(dbServiceDef.getConfigs()) ? new ArrayList<>() : new ArrayList<>(dbServiceDef.getConfigs());
+        RangerServiceConfigDef       config  = copyConfig(embeddedConfig);
+
+        if (isItemIdUsed(configs, config.getItemId())) {
+            config.setItemId(getNextItemId(configs));
+        }
+
+        configs.add(config);
+        dbServiceDef.setConfigs(configs);
+
+        RangerServiceDefValidator validator = validatorFactory.getServiceDefValidator(svcDBStore);
+
+        validator.validate(dbServiceDef, Action.UPDATE);
+        svcDBStore.updateServiceDef(dbServiceDef);
+
+        logger.info("Added config [{}] to service-def [{}]", POLICY_DOWNLOAD_AUTH_GROUPS, SERVICE_DEF_NAME);
+        logger.info("<== PatchForNestedstructureServiceDefUpdate_J10064.updateNestedstructureServiceDef()");
+    }
+
+    private RangerServiceConfigDef copyConfig(RangerServiceConfigDef config) {
+        return new RangerServiceConfigDef(config.getItemId(), config.getName(), config.getType(), config.getSubType(), config.getMandatory(), config.getDefaultValue(),
+                config.getValidationRegEx(), config.getValidationMessage(), config.getUiHint(), config.getLabel(), config.getDescription(), config.getRbKeyLabel(),
+                config.getRbKeyDescription(), config.getRbKeyValidationMessage());
+    }
+
+    private RangerServiceConfigDef findConfigByName(List<RangerServiceConfigDef> configs, String name) {
+        RangerServiceConfigDef ret = null;
+
+        if (CollectionUtils.isNotEmpty(configs)) {
+            for (RangerServiceConfigDef config : configs) {
+                if (config != null && StringUtils.equals(config.getName(), name)) {
+                    ret = config;
+                    break;
+                }
+            }
+        }
+
+        return ret;
+    }
+
+    private boolean isItemIdUsed(List<RangerServiceConfigDef> configs, Long itemId) {
+        boolean ret = false;
+
+        if (itemId != null && CollectionUtils.isNotEmpty(configs)) {
+            for (RangerServiceConfigDef config : configs) {
+                if (config != null && itemId.equals(config.getItemId())) {
+                    ret = true;
+                    break;
+                }
+            }
+        }
+
+        return ret;
+    }
+
+    private Long getNextItemId(List<RangerServiceConfigDef> configs) {
+        long ret = 1;
+
+        if (CollectionUtils.isNotEmpty(configs)) {
+            for (RangerServiceConfigDef config : configs) {
+                if (config != null && config.getItemId() != null) {
+                    ret = Math.max(ret, config.getItemId() + 1);
+                }
+            }
+        }
+
+        return ret;
+    }
+}

--- a/security-admin/src/main/java/org/apache/ranger/patch/PatchForNestedstructureServiceDefUpdate_J10065.java
+++ b/security-admin/src/main/java/org/apache/ranger/patch/PatchForNestedstructureServiceDefUpdate_J10065.java
@@ -37,8 +37,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Component
-public class PatchForNestedstructureServiceDefUpdate_J10064 extends BaseLoader {
-    private static final Logger logger = LoggerFactory.getLogger(PatchForNestedstructureServiceDefUpdate_J10064.class);
+public class PatchForNestedstructureServiceDefUpdate_J10065 extends BaseLoader {
+    private static final Logger logger = LoggerFactory.getLogger(PatchForNestedstructureServiceDefUpdate_J10065.class);
 
     private static final String SERVICE_DEF_NAME            = EmbeddedServiceDefsUtil.EMBEDDED_SERVICEDEF_NESTEDSTRUCTURE_NAME;
     private static final String POLICY_DOWNLOAD_AUTH_GROUPS = "policy.download.auth.groups";
@@ -53,7 +53,7 @@ public class PatchForNestedstructureServiceDefUpdate_J10064 extends BaseLoader {
         logger.info("main()");
 
         try {
-            PatchForNestedstructureServiceDefUpdate_J10064 loader = (PatchForNestedstructureServiceDefUpdate_J10064) CLIUtil.getBean(PatchForNestedstructureServiceDefUpdate_J10064.class);
+            PatchForNestedstructureServiceDefUpdate_J10065 loader = (PatchForNestedstructureServiceDefUpdate_J10065) CLIUtil.getBean(PatchForNestedstructureServiceDefUpdate_J10065.class);
 
             loader.init();
 
@@ -78,25 +78,25 @@ public class PatchForNestedstructureServiceDefUpdate_J10064 extends BaseLoader {
 
     @Override
     public void execLoad() {
-        logger.info("==> PatchForNestedstructureServiceDefUpdate_J10064.execLoad()");
+        logger.info("==> PatchForNestedstructureServiceDefUpdate_J10065.execLoad()");
 
         try {
             updateNestedstructureServiceDef();
         } catch (Exception e) {
-            logger.error("PatchForNestedstructureServiceDefUpdate_J10064.execLoad(): failed", e);
+            logger.error("PatchForNestedstructureServiceDefUpdate_J10065.execLoad(): failed", e);
             System.exit(1);
         }
 
-        logger.info("<== PatchForNestedstructureServiceDefUpdate_J10064.execLoad()");
+        logger.info("<== PatchForNestedstructureServiceDefUpdate_J10065.execLoad()");
     }
 
     @Override
     public void printStats() {
-        logger.info("PatchForNestedstructureServiceDefUpdate_J10064");
+        logger.info("PatchForNestedstructureServiceDefUpdate_J10065");
     }
 
     private void updateNestedstructureServiceDef() throws Exception {
-        logger.info("==> PatchForNestedstructureServiceDefUpdate_J10064.updateNestedstructureServiceDef()");
+        logger.info("==> PatchForNestedstructureServiceDefUpdate_J10065.updateNestedstructureServiceDef()");
 
         RangerServiceDef embeddedServiceDef = EmbeddedServiceDefsUtil.instance().getEmbeddedServiceDef(SERVICE_DEF_NAME);
 
@@ -138,7 +138,7 @@ public class PatchForNestedstructureServiceDefUpdate_J10064 extends BaseLoader {
         svcDBStore.updateServiceDef(dbServiceDef);
 
         logger.info("Added config [{}] to service-def [{}]", POLICY_DOWNLOAD_AUTH_GROUPS, SERVICE_DEF_NAME);
-        logger.info("<== PatchForNestedstructureServiceDefUpdate_J10064.updateNestedstructureServiceDef()");
+        logger.info("<== PatchForNestedstructureServiceDefUpdate_J10065.updateNestedstructureServiceDef()");
     }
 
     private RangerServiceConfigDef copyConfig(RangerServiceConfigDef config) {

--- a/security-admin/src/main/java/org/apache/ranger/rest/RoleREST.java
+++ b/security-admin/src/main/java/org/apache/ranger/rest/RoleREST.java
@@ -98,6 +98,7 @@ public class RoleREST {
     private static List<String> INVALID_USERS = new ArrayList<>();
 
     public static final String POLICY_DOWNLOAD_USERS = "policy.download.auth.users";
+    public static final String POLICY_DOWNLOAD_GROUPS = "policy.download.auth.groups";
     public static final String PARAM_ROLE_NAME = "roleName";
     public static final String PARAM_IMPORT_IN_PROGRESS = "importInProgress";
 
@@ -1057,12 +1058,18 @@ public class RoleREST {
                         isAllowed = true;
                     }else {
                         isAllowed = bizUtil.isUserAllowed(rangerService, POLICY_DOWNLOAD_USERS);
+                        if (!isAllowed) {
+                            isAllowed = bizUtil.isUserInAllowedGroup(rangerService, POLICY_DOWNLOAD_GROUPS);
+                        }
                     }
                 }else{
                     if (isAdmin) {
                         isAllowed = true;
                     }else{
                         isAllowed = bizUtil.isUserAllowed(rangerService, POLICY_DOWNLOAD_USERS);
+                        if (!isAllowed) {
+                            isAllowed = bizUtil.isUserInAllowedGroup(rangerService, POLICY_DOWNLOAD_GROUPS);
+                        }
                     }
                 }
 

--- a/security-admin/src/main/java/org/apache/ranger/rest/ServiceREST.java
+++ b/security-admin/src/main/java/org/apache/ranger/rest/ServiceREST.java
@@ -162,6 +162,7 @@ public class ServiceREST {
 	final static public String PARAM_DELETE_IF_EXISTS = "deleteIfExists";
 	final static public String PARAM_IMPORT_IN_PROGRESS = "importInProgress";
 	public static final String Allowed_User_List_For_Download = "policy.download.auth.users";
+	public static final String Allowed_Group_List_For_Download = "policy.download.auth.groups";
 	public static final String Allowed_User_List_For_Grant_Revoke = "policy.grantrevoke.auth.users";
 
 	public static final String isCSRF_ENABLED = "ranger.rest-csrf.enabled";
@@ -3211,6 +3212,9 @@ public class ServiceREST {
 						if (rangerService != null) {
 							isAllowed = bizUtil.isUserAllowed(rangerService, Allowed_User_List_For_Download);
 							if (!isAllowed) {
+								isAllowed = bizUtil.isUserInAllowedGroup(rangerService, Allowed_Group_List_For_Download);
+							}
+							if (!isAllowed) {
 								isAllowed = bizUtil.isUserAllowed(rangerService, Allowed_User_List_For_Grant_Revoke);
 							}
 						}
@@ -3222,6 +3226,9 @@ public class ServiceREST {
 					} else {
 						if (rangerService != null) {
 							isAllowed = bizUtil.isUserAllowed(rangerService, Allowed_User_List_For_Download);
+							if (!isAllowed) {
+								isAllowed = bizUtil.isUserInAllowedGroup(rangerService, Allowed_Group_List_For_Download);
+							}
 							if (!isAllowed) {
 								isAllowed = bizUtil.isUserAllowed(rangerService, Allowed_User_List_For_Grant_Revoke);
 							}
@@ -4642,5 +4649,4 @@ public class ServiceREST {
 		return ret;
 	}
 }
-
 

--- a/security-admin/src/main/java/org/apache/ranger/rest/TagREST.java
+++ b/security-admin/src/main/java/org/apache/ranger/rest/TagREST.java
@@ -89,6 +89,7 @@ public class TagREST {
     private static final Logger PERF_LOG = RangerPerfTracer.getPerfLogger("rest.TagREST");
 
     public static final String Allowed_User_List_For_Tag_Download = "tag.download.auth.users";
+    public static final String Allowed_Group_List_For_Tag_Download = "tag.download.auth.groups";
 
 	@Autowired
 	RESTErrorUtil restErrorUtil;
@@ -1494,12 +1495,18 @@ public class TagREST {
         			isAllowed = true;
         		}else {
         			isAllowed = bizUtil.isUserAllowed(rangerService, Allowed_User_List_For_Tag_Download);
+				if (!isAllowed) {
+					isAllowed = bizUtil.isUserInAllowedGroup(rangerService, Allowed_Group_List_For_Tag_Download);
+				}
         		}
         	}else{
         		if (isAdmin) {
         			isAllowed = true;
         		}else{
         			isAllowed = bizUtil.isUserAllowed(rangerService, Allowed_User_List_For_Tag_Download);
+				if (!isAllowed) {
+					isAllowed = bizUtil.isUserInAllowedGroup(rangerService, Allowed_Group_List_For_Tag_Download);
+				}
         		}
         	}
         	if (isAllowed) {

--- a/security-admin/src/test/java/org/apache/ranger/biz/TestRangerBizUtil.java
+++ b/security-admin/src/test/java/org/apache/ranger/biz/TestRangerBizUtil.java
@@ -18,7 +18,10 @@ package org.apache.ranger.biz;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.WebApplicationException;
@@ -32,13 +35,16 @@ import org.apache.ranger.common.StringUtil;
 import org.apache.ranger.common.UserSessionBase;
 import org.apache.ranger.db.RangerDaoManager;
 import org.apache.ranger.db.XXAssetDao;
+import org.apache.ranger.db.XXGroupDao;
 import org.apache.ranger.db.XXPortalUserDao;
 import org.apache.ranger.db.XXResourceDao;
 import org.apache.ranger.db.XXUserDao;
 import org.apache.ranger.entity.XXAsset;
+import org.apache.ranger.entity.XXGroup;
 import org.apache.ranger.entity.XXPortalUser;
 import org.apache.ranger.entity.XXResource;
 import org.apache.ranger.entity.XXUser;
+import org.apache.ranger.plugin.model.RangerService;
 import org.apache.ranger.security.context.RangerContextHolder;
 import org.apache.ranger.security.context.RangerSecurityContext;
 import org.apache.ranger.view.VXPortalUser;
@@ -651,5 +657,39 @@ public class TestRangerBizUtil {
                 Mockito.verify(rangerBizUtilMock).blockAuditorRoleUser();
 
         }
+
+	@Test
+	public void testIsUserInAllowedGroupUsesDaoGroupsForKerberosLogin() {
+		RangerSecurityContext context = new RangerSecurityContext();
+		UserSessionBase       session = new UserSessionBase();
+		XXPortalUser          portalUser = new XXPortalUser();
+
+		portalUser.setLoginId("hive/lapa-adh2-latest-1.ru-central1.internal@RU-CENTRAL1.INTERNAL");
+		session.setXXPortalUser(portalUser);
+		context.setUserSession(session);
+		RangerContextHolder.setSecurityContext(context);
+
+		RangerService service = new RangerService();
+		Map<String, String> configs = new HashMap<>();
+		configs.put("policy.download.auth.groups", "spark_users");
+		service.setConfigs(configs);
+
+		XXUserDao userDao = Mockito.mock(XXUserDao.class);
+		XXGroupDao groupDao = Mockito.mock(XXGroupDao.class);
+		XXUser xUser = new XXUser();
+		xUser.setId(7L);
+		xUser.setName("hive");
+		XXGroup xGroup = new XXGroup();
+		xGroup.setName("spark_users");
+
+		Mockito.when(daoManager.getXXUser()).thenReturn(userDao);
+		Mockito.when(daoManager.getXXGroup()).thenReturn(groupDao);
+		Mockito.when(userDao.findByUserName("hive")).thenReturn(xUser);
+		Mockito.when(groupDao.findByUserId(7L)).thenReturn(Collections.singletonList(xGroup));
+
+		Assert.assertTrue(rangerBizUtil.isUserInAllowedGroup(service, "policy.download.auth.groups"));
+		Mockito.verify(userDao).findByUserName("hive");
+		Mockito.verify(groupDao).findByUserId(7L);
+	}
 
 }

--- a/security-admin/src/test/java/org/apache/ranger/rest/TestRoleREST.java
+++ b/security-admin/src/test/java/org/apache/ranger/rest/TestRoleREST.java
@@ -26,6 +26,7 @@ import org.apache.ranger.plugin.model.RangerPolicy;
 import org.apache.ranger.plugin.model.RangerPolicy.RangerPolicyItem;
 import org.apache.ranger.plugin.model.RangerPolicy.RangerPolicyResource;
 import org.apache.ranger.plugin.model.RangerRole;
+import org.apache.ranger.plugin.model.RangerService;
 import org.apache.ranger.plugin.model.validation.RangerRoleValidator;
 import org.apache.ranger.plugin.util.GrantRevokeRoleRequest;
 import org.apache.ranger.plugin.util.RangerRoles;
@@ -814,6 +815,49 @@ public class TestRoleREST {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    @Test
+    public void test17eGetSecureRangerRolesIfUpdatedAllowedByDownloadGroup() throws Exception {
+        RangerRoles rangerRoles = createRangerRoles();
+        rangerRoles.setRoleVersion(2L);
+
+        String serviceName = "serviceName";
+        String pluginId = "pluginId";
+        String clusterName = "";
+        String pluginCapabilities = "";
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+
+        XXService xxService = new XXService();
+        xxService.setId(1L);
+        xxService.setName(serviceName);
+        xxService.setType(1L);
+
+        XXServiceDef xxServiceDef = new XXServiceDef();
+        xxServiceDef.setId(1L);
+        xxServiceDef.setImplclassname("org.apache.ranger.services.hdfs.RangerServiceHdfs");
+
+        RangerService rangerService = new RangerService();
+        rangerService.setName(serviceName);
+
+        Mockito.when(serviceUtil.isValidService(serviceName, request)).thenReturn(true);
+        Mockito.when(daoMgr.getXXService().findByName(serviceName)).thenReturn(xxService);
+        Mockito.when(daoMgr.getXXServiceDef().getById(xxService.getType())).thenReturn(xxServiceDef);
+        Mockito.when(svcStore.getServiceByName(serviceName)).thenReturn(rangerService);
+        Mockito.when(bizUtil.isAdmin()).thenReturn(false);
+        Mockito.when(bizUtil.isKeyAdmin()).thenReturn(false);
+        Mockito.when(bizUtil.isUserAllowed(rangerService, RoleREST.POLICY_DOWNLOAD_USERS)).thenReturn(false);
+        Mockito.when(bizUtil.isUserInAllowedGroup(rangerService, RoleREST.POLICY_DOWNLOAD_GROUPS)).thenReturn(true);
+        Mockito.when(roleStore.getRoles(serviceName, -1L)).thenReturn(rangerRoles);
+
+        RangerRoles returnedRoles = roleRest.getSecureRangerRolesIfUpdated(serviceName, -1L, 0L, pluginId,
+                clusterName, pluginCapabilities, request);
+
+        Assert.assertNotNull(returnedRoles);
+        Assert.assertEquals(serviceName, returnedRoles.getServiceName());
+        Mockito.verify(bizUtil).isUserAllowed(rangerService, RoleREST.POLICY_DOWNLOAD_USERS);
+        Mockito.verify(bizUtil).isUserInAllowedGroup(rangerService, RoleREST.POLICY_DOWNLOAD_GROUPS);
+        Mockito.verify(roleStore).getRoles(serviceName, -1L);
     }
 
 	// empty request roles (requestParamRoles = 0, dbRoles = 5, return = all dbRoles)

--- a/security-admin/src/test/java/org/apache/ranger/rest/TestServiceREST.java
+++ b/security-admin/src/test/java/org/apache/ranger/rest/TestServiceREST.java
@@ -2113,6 +2113,41 @@ public class TestServiceREST {
 	}
 
 	@Test
+	public void test59aGetSecureServicePoliciesIfUpdatedAllowedByDownloadGroup() throws Exception {
+		HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+
+		Long lastKnownVersion = 1L;
+		String pluginId = "1";
+		XXService xService = xService();
+		XXServiceDef xServiceDef = serviceDef();
+		String serviceName = xService.getName();
+		RangerService rs = rangerService();
+		ServicePolicies sp = servicePolicies();
+		XXServiceDefDao xServiceDefDao = Mockito.mock(XXServiceDefDao.class);
+
+		Mockito.when(bizUtil.isAdmin()).thenReturn(false);
+		Mockito.when(bizUtil.isKeyAdmin()).thenReturn(false);
+		Mockito.when(serviceUtil.isValidService(serviceName, request)).thenReturn(true);
+		Mockito.when(daoManager.getXXService()).thenReturn(xServiceDao);
+		Mockito.when(xServiceDao.findByName(serviceName)).thenReturn(xService);
+		Mockito.when(daoManager.getXXServiceDef()).thenReturn(xServiceDefDao);
+		Mockito.when(xServiceDefDao.getById(xService.getType())).thenReturn(xServiceDef);
+		Mockito.when(svcStore.getServiceByName(serviceName)).thenReturn(rs);
+		Mockito.when(bizUtil.isUserAllowed(rs, ServiceREST.Allowed_User_List_For_Download)).thenReturn(false);
+		Mockito.when(bizUtil.isUserInAllowedGroup(rs, ServiceREST.Allowed_Group_List_For_Download)).thenReturn(true);
+		Mockito.when(svcStore.getServicePoliciesIfUpdated(Mockito.anyString(), Mockito.anyLong(), Mockito.anyBoolean())).thenReturn(sp);
+
+		ServicePolicies dbServiceSecurePolicies = serviceREST.getSecureServicePoliciesIfUpdated(serviceName,
+				lastKnownVersion, 0L, pluginId, "", "", true, capabilityVector, request);
+
+		Assert.assertNotNull(dbServiceSecurePolicies);
+		Mockito.verify(bizUtil).isUserAllowed(rs, ServiceREST.Allowed_User_List_For_Download);
+		Mockito.verify(bizUtil).isUserInAllowedGroup(rs, ServiceREST.Allowed_Group_List_For_Download);
+		Mockito.verify(bizUtil, Mockito.never()).isUserAllowed(rs, ServiceREST.Allowed_User_List_For_Grant_Revoke);
+		Mockito.verify(svcStore).getServicePoliciesIfUpdated(serviceName, lastKnownVersion, false);
+	}
+
+	@Test
 	public void test60getPolicyFromEventTime() throws Exception {
 		HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
 

--- a/security-admin/src/test/java/org/apache/ranger/rest/TestTagREST.java
+++ b/security-admin/src/test/java/org/apache/ranger/rest/TestTagREST.java
@@ -76,6 +76,7 @@ public class TestTagREST {
 	private static Long lastKnownVersion = 10L;
 	private static String pluginId = "1";
 	private static String Allowed_User_List_For_Tag_Download = "tag.download.auth.users";
+	private static String Allowed_Group_List_For_Tag_Download = "tag.download.auth.groups";
 
 	@InjectMocks
 	TagREST tagREST = new TagREST();
@@ -1847,6 +1848,55 @@ public class TestTagREST {
 			Mockito.verify(tagStore).getServiceTagsIfUpdated(serviceName, lastKnownVersion, true);
 		} catch (Exception e) {
 		}
+	}
+
+	@Test
+	public void test55aGetSecureServiceTagsIfUpdatedAllowedByDownloadGroup() {
+		boolean isAdmin = false;
+		boolean isKeyAdmin = false;
+		ServiceTags oldServiceTag = new ServiceTags();
+		oldServiceTag.setServiceName(serviceName);
+		oldServiceTag.setTagVersion(5L);
+
+		XXService xService = new XXService();
+		xService.setId(id);
+		xService.setName(serviceName);
+		xService.setType(5L);
+
+		XXServiceDef xServiceDef = new XXServiceDef();
+		xServiceDef.setId(id);
+		xServiceDef.setVersion(5L);
+
+		RangerService rangerService = new RangerService();
+		rangerService.setId(id);
+		rangerService.setName(serviceName);
+
+		XXServiceDao xXServiceDao = Mockito.mock(XXServiceDao.class);
+		XXServiceDefDao xXServiceDefDao  = Mockito.mock(XXServiceDefDao.class);
+
+		Mockito.when(bizUtil.isAdmin()).thenReturn(isAdmin);
+		Mockito.when(bizUtil.isKeyAdmin()).thenReturn(isKeyAdmin);
+		Mockito.when(daoManager.getXXService()).thenReturn(xXServiceDao);
+		Mockito.when(xXServiceDao.findByName(serviceName)).thenReturn(xService);
+		Mockito.when(daoManager.getXXServiceDef()).thenReturn(xXServiceDefDao);
+		Mockito.when(xXServiceDefDao.getById(xService.getType())).thenReturn(xServiceDef);
+
+		try {
+			Mockito.when(svcStore.getServiceByName(serviceName)).thenReturn(rangerService);
+			Mockito.when(tagStore.getServiceTagsIfUpdated(serviceName, lastKnownVersion, true)).thenReturn(oldServiceTag);
+		} catch (Exception e) {
+		}
+
+		Mockito.when(bizUtil.isUserAllowed(rangerService, Allowed_User_List_For_Tag_Download)).thenReturn(false);
+		Mockito.when(bizUtil.isUserInAllowedGroup(rangerService, Allowed_Group_List_For_Tag_Download)).thenReturn(true);
+
+		ServiceTags result = tagREST.getSecureServiceTagsIfUpdated(serviceName, lastKnownVersion, 0L, pluginId, false, capabilityVector, null);
+
+		Assert.assertNotNull(result.getServiceName());
+		Assert.assertEquals(result.getServiceName(), oldServiceTag.getServiceName());
+		Assert.assertEquals(result.getTagVersion(), oldServiceTag.getTagVersion());
+		Mockito.verify(bizUtil).isUserAllowed(rangerService, Allowed_User_List_For_Tag_Download);
+		Mockito.verify(bizUtil).isUserInAllowedGroup(rangerService, Allowed_Group_List_For_Tag_Download);
 	}
 	
 	@Test


### PR DESCRIPTION
## Summary

This PR fixes the Spark3 + Ranger stale policy cache bypass we reproduced around policy download authorization.

Spark3 runs under the user/session identity, not under a single dedicated service identity like Hive or Impala. Because of that, Spark previously needed `*` in `policy.download.auth.users` and `tag.download.auth.users` to let user-launched Spark apps download Ranger policies. Functionally this works, but it also lets any authorized Spark user call Ranger Admin download APIs and retrieve the full policy/tag bundle.

When `*` is removed, Ranger Admin correctly returns `401/403`, but Spark used to treat that as a normal refresh failure and continue authorizing with already loaded policies or local cache. That means an already running `spark3-shell` could keep access after the user lost download permission.

This PR closes that flow by doing three things:

1. Add group-based policy/tag/role download authorization.
2. Make Spark fail closed on explicit Ranger Admin `401/403`.
3. Isolate local policy cache and audit spool directories by user or group.

## What changed

### Ranger Admin download authorization

Added service config parameters:

```properties
policy.download.auth.groups
tag.download.auth.groups
```

Policy and role download now allow access when the caller matches either:

```properties
policy.download.auth.users
policy.download.auth.groups
```

Tag download now allows access when the caller matches either:

```properties
tag.download.auth.users
tag.download.auth.groups
```

The existing `*` behavior in `*.auth.users` is preserved for compatibility, but Spark managed configs no longer need to use it. A Spark service can now be configured with a real trusted group instead:

```properties
policy.download.auth.groups=spark_users
tag.download.auth.groups=spark_users
```

Group membership is checked through Ranger's user/group store. Kerberos login IDs are normalized into candidate short names, so principals like `user@REALM` and `service/host@REALM` can still match Ranger users/groups stored as short names.

### Spark fail-closed behavior

`RangerAdminRESTClient` now treats `401` and `403` as a dedicated access-denied refresh condition.

A new exception was added:

```java
RangerAdminClientAccessDeniedException
```

It is thrown for policy, role, and tag download when Ranger Admin explicitly denies access.

Refresh code handles this differently from transient failures:

```text
401/403                -> mark refresh authz as denied, do not fall back to stale cache
timeout/network/5xx    -> keep existing last-known behavior
successful refresh     -> clear the authz-denied state
```

The behavior is controlled by:

```properties
ranger.plugin.<service>.policy.refresh.authz.denied.mode=failclosed
```

For Spark this must be present in the generated Spark Ranger config:

```properties
ranger.plugin.spark.policy.refresh.authz.denied.mode=failclosed
```

The default remains `continue` for compatibility, so this config is required for the Spark security fix to be active.

When enabled, the plugin denies new authorization checks while policy/role/tag refresh is in authz-denied state. This covers regular access checks, batch checks, row filters, and data masking.

### Policy cache isolation

Added policy cache subdir mode:

```properties
ranger.plugin.spark.policy.cache.subdir.mode=disabled|peruser|pergroup
```

Modes:

```text
disabled -> existing shared directory behavior
peruser  -> $base/$USER,  dir 0700, files 0600
pergroup -> $base/$GROUP, dir 0770, files 0660
```

This is used by policy cache, role cache, and tag cache.

For `peruser`, the directory name is based on the Hadoop UGI short user, but the expected filesystem owner is the actual Linux process user. This fixes cases where Spark runs with a Kerberos user like `spark_user4`, while the local process UID is a different OS user like `scar2`.

For `pergroup`, the group is resolved from Hadoop UGI. If UGI returns a private group equal to the username first, the resolver skips it and uses the first non-private group. This avoids `pergroup` accidentally behaving like `peruser`.

The resolver also:

- rejects unsafe user/group path elements;
- rejects empty values, path separators, and `..`;
- rejects symlinks;
- rejects existing directories/files with unsafe owner/group/permissions;
- handles concurrent directory creation by another Spark process.

The shared base directory must already exist with the configured base permissions. The plugin only creates the final `$USER` or `$GROUP` leaf directory.

### Audit spool isolation

Added audit spool subdir mode:

```properties
xasecure.audit.destination.solr.batch.filespool.subdir.mode=disabled|peruser|pergroup
```

Modes are the same:

```text
disabled -> existing shared spool behavior
peruser  -> $base/$USER,  dir 0700, files 0600
pergroup -> $base/$GROUP, dir 0770, files 0660
```

This is wired into the audit file spool paths, including Solr batch file spool. The code now reads the correct property:

```properties
xasecure.audit.destination.solr.batch.filespool.subdir.mode
```

instead of accidentally looking for:

```properties
xasecure.audit.destination.solr.batch.subdir.mode
```

Archive directories and spool/index files are also secured with the resolved per-user/per-group permissions.

## Why this is needed

The unsafe flow before this fix was:

```text
user has access
Spark downloads policies
admin revokes access or removes download permission
Ranger Admin returns 403
Spark treats it as a normal refresh failure
Spark keeps authorizing with stale policies
```

After this PR, with `failclosed` enabled:

```text
user has access
Spark downloads policies
admin revokes access or removes user from the Spark download group
Ranger Admin returns 403
Spark marks refresh authz as denied
new access checks are denied
```

So revocation takes effect after the next policy refresh instead of being bypassed by stale cache.

### Config example:

```properties
policy.download.auth.users=
tag.download.auth.users=
policy.download.auth.groups=spark_users
tag.download.auth.groups=spark_users

ranger.plugin.spark.policy.refresh.authz.denied.mode=failclosed
ranger.plugin.spark.policy.cache.subdir.mode=peruser
xasecure.audit.destination.solr.batch.filespool.subdir.mode=peruser
```