### PR TITLE
[ADH-5806] Support non-HA Ozone configuration in OzoneClient

### DIFF
--- a/dev-support/ranger-docker/.env
+++ b/dev-support/ranger-docker/.env
@@ -11,22 +11,22 @@ BUILD_OPTS=
 # Java version for RangerBase ubuntu image.
 # This image gets used as base docker image for all images.
 # Valid values: 8, 11, 17
-RANGER_BASE_JAVA_VERSION=8
+RANGER_BASE_JAVA_VERSION=11
 
 # Java version for RangerBase ubi image.
 # This image gets used as base docker image for all images.
 # Valid values: 1.8.0, 11, 17
-RANGER_BASE_UBI_JAVA_VERSION=1.8.0
+RANGER_BASE_UBI_JAVA_VERSION=11
 
 # Java version to use to build Apache Ranger
 # Valid values: 8, 11, 17
 # Trino builds on jdk 11 and above
-RANGER_BUILD_JAVA_VERSION=8
+RANGER_BUILD_JAVA_VERSION=11
 
 # Java version to use to run Ranger Admin server
 # Valid values: 8, 11, 17
 # Should be same as RANGER_BASE_UBI_JAVA_VERSION when running on UBI BASE image.
-RANGER_ADMIN_JAVA_VERSION=8
+RANGER_ADMIN_JAVA_VERSION=11
 
 # base image versions
 UBUNTU_VERSION=20.04
@@ -55,20 +55,20 @@ OZONE_RUNNER_IMAGE=apache/ozone-runner
 OZONE_OPTS=
 
 # versions of ranger services
-RANGER_VERSION=2.6.0
-KMS_VERSION=2.6.0
-USERSYNC_VERSION=2.6.0
-TAGSYNC_VERSION=2.6.0
+RANGER_VERSION=2.6.0.7-2.2.0-3
+KMS_VERSION=2.6.0.7-2.2.0-3
+USERSYNC_VERSION=2.6.0.7-2.2.0-3
+TAGSYNC_VERSION=2.6.0.7-2.2.0-3
 
 # plugin versions
-HDFS_PLUGIN_VERSION=2.6.0
-YARN_PLUGIN_VERSION=2.6.0
-HIVE_PLUGIN_VERSION=2.6.0
-HBASE_PLUGIN_VERSION=2.6.0
-KAFKA_PLUGIN_VERSION=2.6.0
-KNOX_PLUGIN_VERSION=2.6.0
-TRINO_PLUGIN_VERSION=2.6.0
-OZONE_PLUGIN_VERSION=2.6.0
+HDFS_PLUGIN_VERSION=2.6.0.7-2.2.0-3
+YARN_PLUGIN_VERSION=2.6.0.7-2.2.0-3
+HIVE_PLUGIN_VERSION=2.6.0.7-2.2.0-3
+HBASE_PLUGIN_VERSION=2.6.0.7-2.2.0-3
+KAFKA_PLUGIN_VERSION=2.6.0.7-2.2.0-3
+KNOX_PLUGIN_VERSION=2.6.0.7-2.2.0-3
+TRINO_PLUGIN_VERSION=2.6.0.7-2.2.0-3
+OZONE_PLUGIN_VERSION=2.6.0.7-2.2.0-3
 
 # To enable debug logs
 DEBUG_ADMIN=false

--- a/plugin-ozone/src/main/java/org/apache/ranger/services/ozone/client/OzoneClient.java
+++ b/plugin-ozone/src/main/java/org/apache/ranger/services/ozone/client/OzoneClient.java
@@ -56,8 +56,13 @@ public class OzoneClient extends BaseClient {
             }
         }
         SubjectUtil.doAs(getLoginSubject(), (PrivilegedExceptionAction<Void>) () -> {
-            String[] serviceIds = conf.getTrimmedStrings("ozone.om.service.ids", "ozone1");
-            ozoneClient = OzoneClientFactory.getRpcClient(serviceIds[0], conf);
+            String[] serviceIds = conf.getTrimmedStrings("ozone.om.service.ids");
+            if (serviceIds.length > 0) {
+                ozoneClient = OzoneClientFactory.getRpcClient(serviceIds[0], conf);
+            } else {
+                // No service ids configured - non-HA, resolve via ozone.om.address
+                ozoneClient = OzoneClientFactory.getRpcClient(conf);
+            }
             return null;
         });
     }


### PR DESCRIPTION
During the ADH-5806 bug reproduction, it was discovered that Ozone client instantiation used in Ranger doesn't support non-HA configs. This PR fixes this issue.